### PR TITLE
Add syntax highlight for the code

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,8 @@ baseURL = "https://gin-gonic.com/"
 languageCode = "en-us"
 title = "Gin Web Framework"
 theme = "airspace"
+pygmentsCodeFences = true
+pygmentsStyle = "monokailight"
 
 [menu]
 


### PR DESCRIPTION
Hugo already support syntax highlighting for code. The theme i've choosen is `monokailight` and looks like
![screenshot from 2018-10-22 09-09-55](https://user-images.githubusercontent.com/20517048/47281386-12841400-d5db-11e8-9593-8601a68b8a38.png)


The default theme is:
![screenshot from 2018-10-22 09-10-15](https://user-images.githubusercontent.com/20517048/47281377-06985200-d5db-11e8-9408-701d2167dfb3.png)
