### PR TITLE
Add a deployment guide

### DIFF
--- a/content/en/docs/deployment/_index.md
+++ b/content/en/docs/deployment/_index.md
@@ -1,0 +1,23 @@
+---
+title: "Deployment"
+draft: false
+weight: 6
+---
+
+Gin projects can be deployed easily on any cloud provider.
+
+* **[Render](https://render.com)**
+<p>
+Render is a modern cloud platform that offers native support for Go, fully managed SSL, databases, zero-downtime deploys, HTTP/2, and websocket support.
+</p>
+<p>
+Follow the Render [guide to deploying Gin projects](https://render.com/docs/deploy-go-gin).
+</p>
+
+* **[Google App Engine](https://cloud.google.com/appengine/)**
+<p>
+GAE has two ways to deploy Go applications. The standard environment is easier to use but less customizable and prevents [syscalls](https://github.com/gin-gonic/gin/issues/1639) for security reasons. The flexible environment can run any framework or library.
+</p>
+<p>
+Learn more and pick your preferred environment at [Go on Google App Engine](https://cloud.google.com/appengine/docs/go/).
+</p>


### PR DESCRIPTION
Added a couple of options for deploying Gin projects.

Disclosure: I work at [Render](https://render.com).