### PR TITLE
Fix invalid link in custom-validators

### DIFF
--- a/content/en/docs/examples/custom-validators.md
+++ b/content/en/docs/examples/custom-validators.md
@@ -67,4 +67,4 @@ $ curl "localhost:8085/bookable?check_in=2018-03-08&check_out=2018-03-09"
 ```
 
 [Struct level validations](https://github.com/go-playground/validator/releases/tag/v8.7) can also be registered this way.
-See the [struct-lvl-validation example](examples/struct-lvl-validations) to learn more.
+See the [struct-lvl-validation example](https://github.com/gin-gonic/examples/tree/master/struct-lvl-validations) to learn more.


### PR DESCRIPTION
Original link got 404 on GitHub page.