### PR TITLE
Translate controlling-log-output-coloring.md into ja

### DIFF
--- a/content/ja/docs/examples/controlling-log-output-coloring.md
+++ b/content/ja/docs/examples/controlling-log-output-coloring.md
@@ -1,15 +1,15 @@
 ---
-title: "Controlling Log output coloring"
+title: "ログ出力の色付けを制御する"
 draft: false
 ---
 
-By default, logs output on console should be colorized depending on the detected TTY.
+デフォルトでは、ログ出力は検出された TTY に応じて色付けされます。
 
-Never colorize logs:
+ログの色付けを止めるには:
 
 ```go
 func main() {
-    // Disable log's color
+    // ログの色付けを無効にする:
     gin.DisableConsoleColor()
 
     // Creates a gin router with default middleware:
@@ -24,11 +24,11 @@ func main() {
 }
 ```
 
-Always colorize logs:
+常にログの色付けをするには:
 
 ```go
 func main() {
-    // Force log's color
+    // ログの色付けを常にに有効にする:
     gin.ForceConsoleColor()
 
     // Creates a gin router with default middleware:

--- a/content/ja/docs/examples/controlling-log-output-coloring.md
+++ b/content/ja/docs/examples/controlling-log-output-coloring.md
@@ -28,7 +28,7 @@ func main() {
 
 ```go
 func main() {
-    // ログの色付けを常にに有効にする:
+    // ログの色付けを常に有効にする:
     gin.ForceConsoleColor()
 
     // Creates a gin router with default middleware:

--- a/content/ja/docs/examples/controlling-log-output-coloring.md
+++ b/content/ja/docs/examples/controlling-log-output-coloring.md
@@ -1,0 +1,44 @@
+---
+title: "Controlling Log output coloring"
+draft: false
+---
+
+By default, logs output on console should be colorized depending on the detected TTY.
+
+Never colorize logs:
+
+```go
+func main() {
+    // Disable log's color
+    gin.DisableConsoleColor()
+
+    // Creates a gin router with default middleware:
+    // logger and recovery (crash-free) middleware
+    router := gin.Default()
+
+    router.GET("/ping", func(c *gin.Context) {
+        c.String(200, "pong")
+    })
+
+    router.Run(":8080")
+}
+```
+
+Always colorize logs:
+
+```go
+func main() {
+    // Force log's color
+    gin.ForceConsoleColor()
+
+    // Creates a gin router with default middleware:
+    // logger and recovery (crash-free) middleware
+    router := gin.Default()
+
+    router.GET("/ping", func(c *gin.Context) {
+        c.String(200, "pong")
+    })
+
+    router.Run(":8080")
+}
+```

--- a/content/zh-cn/docs/examples/controlling-log-output-coloring.md
+++ b/content/zh-cn/docs/examples/controlling-log-output-coloring.md
@@ -1,0 +1,45 @@
+---
+title: "Controlling Log output coloring"
+draft: false
+---
+
+By default, logs output on console should be colorized depending on the detected TTY.
+
+Never colorize logs:
+
+```go
+func main() {
+    // Disable log's color
+    gin.DisableConsoleColor()
+
+    // Creates a gin router with default middleware:
+    // logger and recovery (crash-free) middleware
+    router := gin.Default()
+
+    router.GET("/ping", func(c *gin.Context) {
+        c.String(200, "pong")
+    })
+
+    router.Run(":8080")
+}
+```
+
+Always colorize logs:
+
+```go
+func main() {
+    // Force log's color
+    gin.ForceConsoleColor()
+
+    // Creates a gin router with default middleware:
+    // logger and recovery (crash-free) middleware
+    router := gin.Default()
+
+    router.GET("/ping", func(c *gin.Context) {
+        c.String(200, "pong")
+    })
+
+    router.Run(":8080")
+}
+```
+

--- a/content/zh-tw/docs/examples/controlling-log-output-coloring.md
+++ b/content/zh-tw/docs/examples/controlling-log-output-coloring.md
@@ -1,0 +1,45 @@
+---
+title: "Controlling Log output coloring"
+draft: false
+---
+
+By default, logs output on console should be colorized depending on the detected TTY.
+
+Never colorize logs:
+
+```go
+func main() {
+    // Disable log's color
+    gin.DisableConsoleColor()
+
+    // Creates a gin router with default middleware:
+    // logger and recovery (crash-free) middleware
+    router := gin.Default()
+
+    router.GET("/ping", func(c *gin.Context) {
+        c.String(200, "pong")
+    })
+
+    router.Run(":8080")
+}
+```
+
+Always colorize logs:
+
+```go
+func main() {
+    // Force log's color
+    gin.ForceConsoleColor()
+
+    // Creates a gin router with default middleware:
+    // logger and recovery (crash-free) middleware
+    router := gin.Default()
+
+    router.GET("/ping", func(c *gin.Context) {
+        c.String(200, "pong")
+    })
+
+    router.Run(":8080")
+}
+```
+


### PR DESCRIPTION
- add missing controlling-log-output-coloring.md to ja, zh-tw, zh-cn.
- translate controlling-log-output-coloring.md into ja (no translate zh-tw and zh-cn)