### PR TITLE
change import path of validator

### DIFF
--- a/content/en/docs/examples/custom-validators.md
+++ b/content/en/docs/examples/custom-validators.md
@@ -14,7 +14,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
-	"gopkg.in/go-playground/validator.v10"
+	"github.com/go-playground/validator/v10"
 )
 
 // Booking contains binded and validated data.


### PR DESCRIPTION
validator v10 change the path to github, as this issue said
https://github.com/go-playground/validator/issues/555#issue-533112571