### PR TITLE
Fix links on deployment docs and use only markdown

### DIFF
--- a/content/en/docs/deployment/_index.md
+++ b/content/en/docs/deployment/_index.md
@@ -6,18 +6,14 @@ weight: 6
 
 Gin projects can be deployed easily on any cloud provider.
 
-* **[Render](https://render.com)**
-<p>
-Render is a modern cloud platform that offers native support for Go, fully managed SSL, databases, zero-downtime deploys, HTTP/2, and websocket support.
-</p>
-<p>
-Follow the Render [guide to deploying Gin projects](https://render.com/docs/deploy-go-gin).
-</p>
+## [Render](https://render.com)
 
-* **[Google App Engine](https://cloud.google.com/appengine/)**
-<p>
+Render is a modern cloud platform that offers native support for Go, fully managed SSL, databases, zero-downtime deploys, HTTP/2, and websocket support.
+
+Follow the Render [guide to deploying Gin projects](https://render.com/docs/deploy-go-gin).
+
+## [Google App Engine](https://cloud.google.com/appengine/)
+
 GAE has two ways to deploy Go applications. The standard environment is easier to use but less customizable and prevents [syscalls](https://github.com/gin-gonic/gin/issues/1639) for security reasons. The flexible environment can run any framework or library.
-</p>
-<p>
+
 Learn more and pick your preferred environment at [Go on Google App Engine](https://cloud.google.com/appengine/docs/go/).
-</p>

--- a/content/ja/docs/deployment/_index.md
+++ b/content/ja/docs/deployment/_index.md
@@ -6,18 +6,15 @@ weight: 6
 
 Gin projects can be deployed easily on any cloud provider.
 
-* **[Render](https://render.com)**
-<p>
-Render is a modern cloud platform that offers native support for Go, fully managed SSL, databases, zero-downtime deploys, HTTP/2, and websocket support.
-</p>
-<p>
-Follow the Render [guide to deploying Gin projects](https://render.com/docs/deploy-go-gin).
-</p>
+## [Render](https://render.com)
 
-* **[Google App Engine](https://cloud.google.com/appengine/)**
-<p>
+Render is a modern cloud platform that offers native support for Go, fully managed SSL, databases, zero-downtime deploys, HTTP/2, and websocket support.
+
+Follow the Render [guide to deploying Gin projects](https://render.com/docs/deploy-go-gin).
+
+## [Google App Engine](https://cloud.google.com/appengine/)
+
 GAE has two ways to deploy Go applications. The standard environment is easier to use but less customizable and prevents [syscalls](https://github.com/gin-gonic/gin/issues/1639) for security reasons. The flexible environment can run any framework or library.
-</p>
-<p>
+
 Learn more and pick your preferred environment at [Go on Google App Engine](https://cloud.google.com/appengine/docs/go/).
-</p>
+

--- a/content/ko-kr/docs/deployment/_index.md
+++ b/content/ko-kr/docs/deployment/_index.md
@@ -6,18 +6,14 @@ weight: 6
 
 Gin 프로젝트는 모든 클라우드 제공 업체에 쉽게 배포 할 수 있습니다.
 
-* **[Render](https://render.com)**
-<p>
-Render은 Go를 기본 지원하는 최신 클라우드 플랫폼으로, SSL관리, 데이터베이스, 무중단 배포, HTTP/2, websocket을 지원합니다.
-</p>
-<p>
-Render의 [Gin프로젝트 배포 가이드](https://render.com/docs/deploy-go-gin)를 참조하세요.
-</p>
+## [Render](https://render.com)
 
-* **[Google App Engine](https://cloud.google.com/appengine/)**
-<p>
+Render은 Go를 기본 지원하는 최신 클라우드 플랫폼으로, SSL관리, 데이터베이스, 무중단 배포, HTTP/2, websocket을 지원합니다.
+
+Render의 [Gin프로젝트 배포 가이드](https://render.com/docs/deploy-go-gin)를 참조하세요.
+
+## [Google App Engine](https://cloud.google.com/appengine/)
+
 GAE에는 Go어플리케이션을 배포하는 두 가지 방법이 있습니다. 표준환경은 간단히 사용할 수 있으나, 사용자 정의가 어려우며 보안상의 이유로 [syscalls](https://github.com/gin-gonic/gin/issues/1639)를 사용할 수 없습니다. 가변형 환경은 모든 프레임워크와 라이브러리를 사용할 수 있습니다.
-</p>
-<p>
+
 [Google App Engine의 Go](https://cloud.google.com/appengine/docs/go/)에서 자세히 알아보고 자신에게 알맞은 환경을 선택하세요.
-</p>

--- a/content/zh-cn/docs/deployment/_index.md
+++ b/content/zh-cn/docs/deployment/_index.md
@@ -6,18 +6,15 @@ weight: 6
 
 Gin 项目可以轻松部署在任何云提供商上。
 
-* **[Render](https://render.com)**
-<p>
-Render 是一个原生支持 Go 的现代化云平台，并支持全托管 SSL、数据库、不停机部署、HTTP/2 和 websocket。
-</p>
-<p>
-参考 Render [Gin 项目部署指南](https://render.com/docs/deploy-go-gin)。
-</p>
+## [Render](https://render.com)
 
-* **[Google App Engine](https://cloud.google.com/appengine/)**
-<p>
+Render 是一个原生支持 Go 的现代化云平台，并支持全托管 SSL、数据库、不停机部署、HTTP/2 和 websocket。
+
+参考 Render [Gin 项目部署指南](https://render.com/docs/deploy-go-gin)。
+
+## [Google App Engine](https://cloud.google.com/appengine/)
+
 GAE 提供了两种方式部署 Go 应用。标准环境，简单易用但可定制性较低，且出于安全考虑禁止 [syscalls](https://github.com/gin-gonic/gin/issues/1639)。灵活环境，可以运行任何框架和库。
-</p>
-<p>
+
 前往 [Go on Google App Engine](https://cloud.google.com/appengine/docs/go/) 了解更多并选择你喜欢的环境。
-</p>
+

--- a/content/zh-tw/docs/deployment/_index.md
+++ b/content/zh-tw/docs/deployment/_index.md
@@ -6,18 +6,15 @@ weight: 6
 
 Gin projects can be deployed easily on any cloud provider.
 
-* **[Render](https://render.com)**
-<p>
-Render is a modern cloud platform that offers native support for Go, fully managed SSL, databases, zero-downtime deploys, HTTP/2, and websocket support.
-</p>
-<p>
-Follow the Render [guide to deploying Gin projects](https://render.com/docs/deploy-go-gin).
-</p>
+## [Render](https://render.com)
 
-* **[Google App Engine](https://cloud.google.com/appengine/)**
-<p>
+Render is a modern cloud platform that offers native support for Go, fully managed SSL, databases, zero-downtime deploys, HTTP/2, and websocket support.
+
+Follow the Render [guide to deploying Gin projects](https://render.com/docs/deploy-go-gin).
+
+## [Google App Engine](https://cloud.google.com/appengine/)
+
 GAE has two ways to deploy Go applications. The standard environment is easier to use but less customizable and prevents [syscalls](https://github.com/gin-gonic/gin/issues/1639) for security reasons. The flexible environment can run any framework or library.
-</p>
-<p>
+
 Learn more and pick your preferred environment at [Go on Google App Engine](https://cloud.google.com/appengine/docs/go/).
-</p>
+


### PR DESCRIPTION
One cannot embed markdown properly in HTML, so the links were displaying incorrectly before:
![Screenshot_2020-04-09_20-25-25](https://user-images.githubusercontent.com/1033027/78959591-42a9c600-7aa0-11ea-880e-e0f33b39c3de.png)

This changes it so that sections are demarcated by level-2 headers and paragraphs no longer need the `<p>` tags. Everything is markdown, so the links work. It also looks cleaner and is more consistent with the rest of Gin's documentation.