### PR TITLE
Forgot to use the newly registered `bookabledate` tag

### DIFF
--- a/content/en/docs/examples/custom-validators.md
+++ b/content/en/docs/examples/custom-validators.md
@@ -19,8 +19,8 @@ import (
 
 // Booking contains binded and validated data.
 type Booking struct {
-	CheckIn  time.Time `form:"check_in" binding:"required" time_format:"2006-01-02"`
-	CheckOut time.Time `form:"check_out" binding:"required,gtfield=CheckIn" time_format:"2006-01-02"`
+	CheckIn  time.Time `form:"check_in" binding:"required,bookabledate" time_format:"2006-01-02"`
+	CheckOut time.Time `form:"check_out" binding:"required,gtfield=CheckIn,bookabledate" time_format:"2006-01-02"`
 }
 
 var bookableDate validator.Func = func(fl validator.FieldLevel) bool {


### PR DESCRIPTION
The example is trying to teach how to create a custom field-level validation but it's not using it.