### PR TITLE
Adjust testing index

### DIFF
--- a/content/en/docs/testing/_index.md
+++ b/content/en/docs/testing/_index.md
@@ -51,6 +51,3 @@ func TestPingRoute(t *testing.T) {
 	assert.Equal(t, "pong", w.Body.String())
 }
 ```
-
-
-

--- a/content/en/docs/testing/_index.md
+++ b/content/en/docs/testing/_index.md
@@ -8,8 +8,7 @@ weight: 7
 
 The `net/http/httptest` package is preferable way for HTTP testing.
 
-{{<highlight go>}}
-
+```go
 package main
 
 import "github.com/gin-gonic/gin"
@@ -26,7 +25,7 @@ func main() {
 	r := setupRouter()
 	r.Run(":8080")
 }
-{{</highlight>}}
+```
 
 Test for code example above:
 

--- a/content/en/docs/testing/_index.md
+++ b/content/en/docs/testing/_index.md
@@ -12,6 +12,8 @@ The `net/http/httptest` package is preferable way for HTTP testing.
 
 package main
 
+import "github.com/gin-gonic/gin"
+
 func setupRouter() *gin.Engine {
 	r := gin.Default()
 	r.GET("/ping", func(c *gin.Context) {


### PR DESCRIPTION
This PR adjusts the testing page, adding the missing import on example code (without it the code won't build) and using the same Go code block style for both code examples.