### PR TITLE
Wrong usage of assert in docs

### DIFF
--- a/content/en/docs/testing/_index.md
+++ b/content/en/docs/testing/_index.md
@@ -47,7 +47,7 @@ func TestPingRoute(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/ping", nil)
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, 200, w.Code)
-	assert.Equal(t, "pong", w.Body.String())
+	assert.Equal(t, w.Code, 200)
+	assert.Equal(t, w.Body.String(), "pong")
 }
 ```


### PR DESCRIPTION
https://gin-gonic.com/docs/testing/ in this page usage of assert.Equal is wrong, second parameter actually is what you got and third is what you expect.

I swap the parameter places.