### PR TITLE
update: set github branch in config file

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -160,6 +160,9 @@ github_repo = "https://github.com/gin-gonic/website"
 # An optional link to a related project repo. For example, the sibling repository where your product code lives.
 github_project_repo = "https://github.com/google/docsy"
 
+# Specify a value here if you have would like to reference a different branch for the other github settings like Edit this page or Create project issue.
+github_branch = "master"
+
 # Specify a value here if your content directory is not in your repo's root directory
 # github_subdir = ""
 


### PR DESCRIPTION
https://www.docsy.dev/docs/adding-content/repository-links/#github_branch-optional
https://github.com/google/docsy/blob/2d3d2c69146b6b9e3a9942c5cf6c7f11a21d0d7a/layouts/partials/page-meta-links.html#L7

docsy will default use "main" branch in side bar link like Edit this page or Create project issue
but in this repo, "master" shoud be the branch for docsy to use

before add github_branch in config:
https://github.com/gin-gonic/website/tree/main/content/en/docs/_index.md

after add github_branch in config:
https://github.com/gin-gonic/website/tree/master/content/en/docs/_index.md