### PR TITLE
Fix installation steps numbering

### DIFF
--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -32,19 +32,19 @@ import "github.com/gin-gonic/gin"
 import "net/http"
 ```
 
-1. Create your project folder and `cd` inside
+4. Create your project folder and `cd` inside
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/myusername/project && cd "$_"
 ```
 
-2. Copy a starting template inside your project
+5. Copy a starting template inside your project
 
 ```sh
 $ curl https://raw.githubusercontent.com/gin-gonic/examples/master/basic/main.go > main.go
 ```
 
-3. Run your project
+6. Run your project
 
 ```sh
 $ go run main.go


### PR DESCRIPTION
Previously, the numbering of the steps reset after 3. This change updates the numbering to 1 through 6.