### PR TITLE
Update graceful-restart-or-stop.md

### DIFF
--- a/content/en/docs/examples/graceful-restart-or-stop.md
+++ b/content/en/docs/examples/graceful-restart-or-stop.md
@@ -61,7 +61,7 @@ func main() {
 
 	// Wait for interrupt signal to gracefully shutdown the server with
 	// a timeout of 5 seconds.
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	// kill (no param) default send syscall.SIGTERM
 	// kill -2 is syscall.SIGINT
 	// kill -9 is syscall. SIGKILL but can"t be catch, so don't need add it

--- a/content/es/docs/examples/graceful-restart-or-stop.md
+++ b/content/es/docs/examples/graceful-restart-or-stop.md
@@ -60,7 +60,7 @@ func main() {
 
 	// Espera por la señal de interrupción para el apagado controlado del servidor
 	// con un tiempo de espera de 5 segundos.
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	// kill (sin parámetro) envío por defecto de la señal syscanll.SIGTERM
 	// kill -2 es syscall.SIGINT
 	// kill -9 es syscall.SIGKILL pero no se puede atrapar, así que no es necesario agregarlo

--- a/content/fa/docs/examples/graceful-restart-or-stop.md
+++ b/content/fa/docs/examples/graceful-restart-or-stop.md
@@ -61,7 +61,7 @@ func main() {
 
 	// Wait for interrupt signal to gracefully shutdown the server with
 	// a timeout of 5 seconds.
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	// kill (no param) default send syscanll.SIGTERM
 	// kill -2 is syscall.SIGINT
 	// kill -9 is syscall. SIGKILL but can"t be catch, so don't need add it

--- a/content/ja/docs/examples/graceful-restart-or-stop.md
+++ b/content/ja/docs/examples/graceful-restart-or-stop.md
@@ -60,7 +60,7 @@ func main() {
 	}()
 
 	// シグナル割り込みを待ち、タイムアウト時間が5秒の graceful shutdown をする
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	// kill (no param) default send syscanll.SIGTERM
 	// kill -2 is syscall.SIGINT
 	// kill -9 is syscall. SIGKILL but can"t be catch, so don't need add it

--- a/content/ko-kr/docs/examples/graceful-restart-or-stop.md
+++ b/content/ko-kr/docs/examples/graceful-restart-or-stop.md
@@ -60,7 +60,7 @@ func main() {
 	}()
 
 	// 5초의 타임아웃으로 인해 인터럽트 신호가 서버를 정상종료 할 때까지 기다립니다.
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	// kill (파라미터 없음) 기본값으로 syscanll.SIGTERM를 보냅니다
 	// kill -2 는 syscall.SIGINT를 보냅니다
 	// kill -9 는 syscall.SIGKILL를 보내지만 캐치할수 없으므로, 추가할 필요가 없습니다.

--- a/content/pt/docs/examples/graceful-restart-or-stop.md
+++ b/content/pt/docs/examples/graceful-restart-or-stop.md
@@ -61,7 +61,7 @@ func main() {
 
 	// Wait for interrupt signal to gracefully shutdown the server with
 	// a timeout of 5 seconds.
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	// kill (no param) default send syscanll.SIGTERM
 	// kill -2 is syscall.SIGINT
 	// kill -9 is syscall. SIGKILL but can"t be catch, so don't need add it

--- a/content/tr/docs/examples/graceful-restart-or-stop.md
+++ b/content/tr/docs/examples/graceful-restart-or-stop.md
@@ -61,7 +61,7 @@ func main() {
 
 	// Wait for interrupt signal to gracefully shutdown the server with
 	// a timeout of 5 seconds.
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	// kill (no param) default send syscanll.SIGTERM
 	// kill -2 is syscall.SIGINT
 	// kill -9 is syscall. SIGKILL but can"t be catch, so don't need add it

--- a/content/zh-cn/docs/examples/graceful-restart-or-stop.md
+++ b/content/zh-cn/docs/examples/graceful-restart-or-stop.md
@@ -58,7 +58,7 @@ func main() {
 	}()
 
 	// 等待中断信号以优雅地关闭服务器（设置 5 秒的超时时间）
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 	<-quit
 	log.Println("Shutdown Server ...")

--- a/content/zh-tw/docs/examples/graceful-restart-or-stop.md
+++ b/content/zh-tw/docs/examples/graceful-restart-or-stop.md
@@ -60,7 +60,7 @@ func main() {
 
 	// Wait for interrupt signal to gracefully shutdown the server with
 	// a timeout of 5 seconds.
-	quit := make(chan os.Signal)
+	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, os.Interrupt)
 	<-quit
 	log.Println("Shutdown Server ...")


### PR DESCRIPTION
Package signal will not block sending to c: the caller must ensure that c has sufficient buffer space to keep up with the expected signal rate. For a channel used for notification of just one signal value,a buffer of size 1 is sufficient.