### PR TITLE
Update bind-uri.md

### DIFF
--- a/content/en/docs/examples/bind-uri.md
+++ b/content/en/docs/examples/bind-uri.md
@@ -20,7 +20,7 @@ func main() {
 	route.GET("/:name/:id", func(c *gin.Context) {
 		var person Person
 		if err := c.ShouldBindUri(&person); err != nil {
-			c.JSON(400, gin.H{"msg": err})
+			c.JSON(400, gin.H{"msg": err.Error()})
 			return
 		}
 		c.JSON(200, gin.H{"name": person.Name, "uuid": person.ID})


### PR DESCRIPTION
- fix the err msg typo
- gin.H{"msg": err} will return `{"msg":[{}]}` when binder failed
- gin.H{"msg": err.Error()} will return a pretty error message when the binder failed, for example, {"msg":"Key: 'Person.ID' Error:Field validation for 'ID' failed on the 'uuid' tag"}