### PR TITLE
docs: update bind-query-or-post.md example to be more understandable

### DIFF
--- a/content/en/docs/examples/bind-query-or-post.md
+++ b/content/en/docs/examples/bind-query-or-post.md
@@ -32,7 +32,7 @@ func startPage(c *gin.Context) {
 	// If `GET`, only `Form` binding engine (`query`) used.
 	// If `POST`, first checks the `content-type` for `JSON` or `XML`, then uses `Form` (`form-data`).
 	// See more at https://github.com/gin-gonic/gin/blob/master/binding/binding.go#L48
-	if c.ShouldBind(&person) == nil {
+	if err := c.ShouldBind(&person); err == nil {
 		log.Println(person.Name)
 		log.Println(person.Address)
 		log.Println(person.Birthday)


### PR DESCRIPTION
The `c.ShouldBind()` is returned `error` type, so it would be better to understand if we provide the example that assign to `err` variable first before check if `err` is `nil`.