### PR TITLE
fix: Add a clear instruction on how to define an HTML template file.

### DIFF
--- a/content/en/docs/examples/html-rendering.md
+++ b/content/en/docs/examples/html-rendering.md
@@ -49,6 +49,8 @@ func main() {
 }
 ```
 
+**Note:** Please wrap your HTML template in the `{{define <template-path>}} {{end}}` block and define your template file with the relative path `<template-path>`. Otherwise, GIN will not properly parse the template files.
+
 templates/posts/index.tmpl
 
 ```html


### PR DESCRIPTION
fixes https://github.com/gin-gonic/gin/issues/3801

### Description
- Add a clear instruction on how to define an HTML template file in https://gin-gonic.com/docs/examples/html-rendering/