### PR TITLE
docs: fix typo at ascii-json.md korean documentation

### DIFF
--- a/content/ko-kr/docs/examples/ascii-json.md
+++ b/content/ko-kr/docs/examples/ascii-json.md
@@ -3,7 +3,7 @@ title: "AsciiJSON"
 draft: false
 ---
 
-이스케이프 된 비 ASCII chracter를 AsciiJSON을 사용하여 ASCII 전용 JSON을 생성합니다
+이스케이프 된 비 ASCII character를 AsciiJSON을 사용하여 ASCII 전용 JSON을 생성합니다
 
 ```go
 func main() {


### PR DESCRIPTION
Hello.

I found an typo issue of `chracter` and fixed it.

Thanks.
