### PR TITLE
Update the documentation to explain configuration items.

### DIFF
--- a/content/en/docs/deployment/_index.md
+++ b/content/en/docs/deployment/_index.md
@@ -29,3 +29,42 @@ Follow the Render [guide to deploying Gin projects](https://render.com/docs/depl
 GAE has two ways to deploy Go applications. The standard environment is easier to use but less customizable and prevents [syscalls](https://github.com/gin-gonic/gin/issues/1639) for security reasons. The flexible environment can run any framework or library.
 
 Learn more and pick your preferred environment at [Go on Google App Engine](https://cloud.google.com/appengine/docs/go/).
+
+
+## Self Hosted
+Gin projects can also be deployed in a self-hosted manner. Deployment architecture and security considerations vary depending on the target environment. The following section only presents a high level overview of configuration options to consider when planning the deployment.
+
+## Configuration Options
+Gin project deployments can be tuned by using environment variables or directly in code. 
+
+The following environment variables are available for configuring Gin:
+
+| Environment Variable | Description |
+|----------------------|-------------|
+| PORT | The TCP port to listen on when starting the Gin server with `router.Run()` (i.e. without any arguments). |
+| GIN_MODE | Set to one of `debug`, `release`, or `test`. Handles management of Gin modes, such as when to emit debug outputs. Can also be set in code using `gin.SetMode(gin.ReleaseMode)` or `gin.SetMode(gin.TestMode)`|
+
+The following code can be used to configure Gin.
+
+```go
+// Don't specify the bind address or port for Gin. Defaults to binding on all interfaces on port 8080.
+// Can use the `PORT` environment variable to change the listen port when using `Run()` without any arguments.
+router := gin.Default()
+router.Run()
+
+// Specify the bind address and port for Gin.
+router := gin.Default()
+router.Run("192.168.1.100:8080")
+
+// Specify only the listen port. Will bind on all interfaces.
+router := gin.Default()
+router.Run(":8080")
+
+// Set which IP addresses or CIDRs, are considered to be trusted for setting headers to document real client IP addresses.
+// See the documentation for additional details.
+router := gin.Default()
+router.SetTrustedProxies([]string{"192.168.1.2"})
+```
+
+## Don't Trust All Proxies
+By default, Gin will trust all proxies. This should be considered and tuned according to your deployment architecture. See the [Gin Documentation](https://github.com/gin-gonic/gin/blob/master/docs/doc.md#dont-trust-all-proxies) for additional details.

--- a/content/en/docs/quickstart/_index.md
+++ b/content/en/docs/quickstart/_index.md
@@ -89,3 +89,5 @@ And, You can run the code via `go run example.go`:
 # run example.go and visit 0.0.0.0:8080/ping on browser
 $ go run example.go
 ```
+
+Additional information is available from the [Gin source code repository](https://github.com/gin-gonic/gin/blob/master/docs/doc.md).


### PR DESCRIPTION
Some improvements are made to the documentation to mention ways we can configure the Gin runtime.

Also add a link to additional sources of information. The Gin website and Gin framework are hosted in separate code repositories, and there is a split in areas users can find documentation.

Supports #140 