### PR TITLE
fix example curl command

### DIFF
--- a/content/en/docs/examples/upload-file/multiple-file.md
+++ b/content/en/docs/examples/upload-file/multiple-file.md
@@ -31,7 +31,7 @@ How to `curl`:
 
 ```sh
 curl -X POST http://localhost:8080/upload \
-  -F "upload[]=@/Users/appleboy/test1.zip" \
-  -F "upload[]=@/Users/appleboy/test2.zip" \
+  -F "files=@/Users/appleboy/test1.zip" \
+  -F "files=@/Users/appleboy/test2.zip" \
   -H "Content-Type: multipart/form-data"
 ```


### PR DESCRIPTION
The example curl command shown for the multi file upload example doesnt work, adjust command accordingly.

example wont work:

```
curl -X POST http://localhost:8080/upload   -F "upload[]=@/tmp/file1"   -F "upload[]=@/tmp/file2"   -H "Content-Type: multipart/form-data"
Uploaded successfully 0 files with fields name= and email=.
```

working command:


```
curl -X POST http://localhost:8080/upload   -F "files=@/tmp/file1"   -F "files=@/tmp/file2"   -H "Content-Type: multipart/form-data"
Uploaded successfully 2 files with fields name= and email=.
```