### PR TITLE
html-rendering.md: Added paragraph about html/template and text/template

### DIFF
--- a/content/en/docs/examples/html-rendering.md
+++ b/content/en/docs/examples/html-rendering.md
@@ -3,7 +3,10 @@ title: "HTML rendering"
 draft: false
 ---
 
-Using LoadHTMLGlob() or LoadHTMLFiles()
+Gin uses the [html/template](https://pkg.go.dev/html/template) package for HTML rendering.
+For more information about how to use them, including available placeholders, see the documentation for [text/template](https://pkg.go.dev/text/template)
+
+Use LoadHTMLGlob() or LoadHTMLFiles() to select the HTML files to load.
 
 ```go
 func main() {


### PR DESCRIPTION
I'm new to Go and Gin development and was initially confused about how templates work. I've added a quick paragraph to make this information in the Go docs easier to find