### PR TITLE
Update _index.md of ja/docs according to en/docs

### DIFF
--- a/content/ja/docs/quickstart/_index.md
+++ b/content/ja/docs/quickstart/_index.md
@@ -20,6 +20,12 @@ Gin をインストールするには、まず Go のインストールおよび
 $ go get -u github.com/gin-gonic/gin
 ```
 
+もしくは次の方法でインストールします。
+
+```sh
+$ go install github.com/gin-gonic/gin@latest
+```
+
 2. コード内でインポートする
 
 ```go


### PR DESCRIPTION
There was no description of `go install` in the Japanese documentation.

It exists in the English documentation, so I have updated it.

- https://gin-gonic.com/docs/quickstart/

Best regards
