### PR TITLE
Fix graceful restart or stop example code

### DIFF
--- a/content/en/docs/examples/graceful-restart-or-stop.md
+++ b/content/en/docs/examples/graceful-restart-or-stop.md
@@ -55,7 +55,7 @@ func main() {
 	go func() {
 		// service connections
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("listen: %s\n", err)
+			log.Println("listen:", err)
 		}
 	}()
 
@@ -78,6 +78,8 @@ func main() {
 	select {
 	case <-ctx.Done():
 		log.Println("timeout of 5 seconds.")
+	default:
+		break
 	}
 	log.Println("Server exiting")
 }


### PR DESCRIPTION
When context timeout reached, `svr.Shutdown` will return a context err, thus `log.Fatal` should be replaced with `log.Println` to allow following cleaning up code to run.  