### PR TITLE
Fix graceful restart or stop example code

### DIFF
--- a/content/en/docs/examples/graceful-restart-or-stop.md
+++ b/content/en/docs/examples/graceful-restart-or-stop.md
@@ -72,12 +72,14 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatal("Server Shutdown:", err)
+		log.Println("Server Shutdown:", err)
 	}
 	// catching ctx.Done(). timeout of 5 seconds.
 	select {
 	case <-ctx.Done():
 		log.Println("timeout of 5 seconds.")
+	default:
+		break
 	}
 	log.Println("Server exiting")
 }


### PR DESCRIPTION
When context timeout reached, `svr.Shutdown` will return a context err, thus `log.Fatal` should be called to stop following cleaning up code. 