### PR TITLE
Fix landing page horizontal scroll

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 {{ $links := .Site.Params.links }}
 <footer class="bg-dark py-5 row d-print-none" style="min-height:60px;padding-top:1rem !important">
-  <div class="container-fluid mx-sm-5">
+  <div class="container-fluid ml-sm-5">
     <div class="row">
       <div class="col-6 col-sm-4 text-xs-center order-sm-2">
         {{ with $links }}


### PR DESCRIPTION
There is currently a margin on the right overflowing in the footer causing the whole landing page to be horizontally scrollable (see image below below):

Also this is my first (albiet small) open source PR! Please let me know if there's anything I can improve 👍 

<img width="1512" alt="Screenshot 2025-01-05 at 4 18 20 pm" src="https://github.com/user-attachments/assets/c7f14d8a-50f4-4c44-a17e-ec4fbd90d66c" />
