### PR TITLE
fix missing packages in testing docs

### DIFF
--- a/content/en/docs/testing/_index.md
+++ b/content/en/docs/testing/_index.md
@@ -50,7 +50,9 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+        "encoding/json"
 	"testing"
+        "strings"
 
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
The `strings` and `encoding/json` package were missing from the testing example. I have added them to help with understanding.