### PR TITLE
feat: Supported dark mode

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -3,6 +3,7 @@
 Add styles or override variables from the theme here.
 
 */
+@import 'td/code-dark';
 
 $primary: #3176d9 !default;
 $dark: #3176d9 !default;

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gin-gonic/website
 go 1.22.2
 
 require (
-	github.com/google/docsy v0.9.2-0.20240426161215-e9eca0fcb3b5 // indirect
-	github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 // indirect
+	github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de // indirect
+	github.com/google/docsy v0.11.0 // indirect
 	github.com/twbs/bootstrap v5.3.3+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,16 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7 h1:2aWEKCRLqQ9nPyXaz4/IYtRrDr3PzEiX0DUSUr2/EDs=
 github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de h1:JvHOfdSqvArF+7cffH9oWU8oLhn6YFYI60Pms8M/6tI=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/FortAwesome/Font-Awesome v4.7.0+incompatible h1:3trjm7NtX5NXlju1AxSWSzedDMq2hsfH78Qtqrc8EgY=
 github.com/FortAwesome/Font-Awesome v4.7.0+incompatible/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
 github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
 github.com/google/docsy v0.9.2-0.20240426161215-e9eca0fcb3b5 h1:EDs9FRTZ75agHdnMeO3HjfqJV10jKpdsM6XEARy/FsM=
 github.com/google/docsy v0.9.2-0.20240426161215-e9eca0fcb3b5/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/google/docsy v0.11.0 h1:QnV40cc28QwS++kP9qINtrIv4hlASruhC/K3FqkHAmM=
+github.com/google/docsy v0.11.0/go.mod h1:hGGW0OjNuG5ZbH5JRtALY3yvN8ybbEP/v2iaK4bwOUI=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v5.3.3+incompatible h1:goFoqinzdHfkeegpFP7pvhbd0g+A3O2hbU3XCjuNrEQ=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/hugo.toml
+++ b/hugo.toml
@@ -22,7 +22,7 @@ pygmentsUseClasses = false
 pygmentsUseClassic = false
 #pygmentsOptions = "linenos=table"
 # See https://help.farbox.com/pygments.html
-pygmentsStyle = "tango"
+# pygmentsStyle = "tango"
 
 # First one is picked as the Twitter card image if not set on page.
 #images = ["images/project-illustration.png"]
@@ -144,6 +144,8 @@ time_format_default = "02.01.2006"
 time_format_blog = "02.01.2006"
 
 [markup]
+  [markup.highlight]
+    noClasses = false
   [markup.goldmark]
     [markup.goldmark.renderer]
       unsafe = true

--- a/hugo.toml
+++ b/hugo.toml
@@ -201,6 +201,8 @@ sidebar_search_disable = true
 navbar_logo = true
 # Set to true to disable the About link in the site footer
 footer_about_enable = true
+# Set to true to enable dark/light mode toggle
+showLightDarkModeMenu = true
 
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.


### PR DESCRIPTION
- Upgrade docsy to v0.11.0
- Add config to enable light/dark toggle
- Fixed code block style to be compatible with dark mode

![image](https://github.com/user-attachments/assets/28a037ba-e4e0-44e1-9ce9-3662f13488a4)


ref:
- https://www.docsy.dev/docs/adding-content/lookandfeel/#lightdark-color-themes
- https://www.docsy.dev/docs/adding-content/lookandfeel/#lightdark-mode-menu