### PR TITLE
fix: multipartfile wrong files field

### DIFF
--- a/content/en/docs/examples/upload-file/multiple-file.md
+++ b/content/en/docs/examples/upload-file/multiple-file.md
@@ -13,7 +13,7 @@ func main() {
 	router.POST("/upload", func(c *gin.Context) {
 		// Multipart form
 		form, _ := c.MultipartForm()
-		files := form.File["upload[]"]
+		files := form.File["files"]
 
 		for _, file := range files {
 			log.Println(file.Filename)


### PR DESCRIPTION
fix: multipartfile wrong files field


According to the `curl` test command in the [document](https://gin-gonic.com/docs/examples/upload-file/multiple-file/), the key for uploading files is `files`, but the code in the example uses `upload[]` to get the file list.

Do `Chinese documents` need to be synchronized with `English documents`? I see that currently Chinese documents use `upload[]` as the key for uploaded files.
