### PR TITLE
Update broken URL in the English version of the Introduction document.

### DIFF
--- a/src/content/docs/en/docs/introduction/index.md
+++ b/src/content/docs/en/docs/introduction/index.md
@@ -8,7 +8,7 @@ Gin is a web framework written in Go (Golang). It features a martini-like API wi
 
 In this section we will walk through what Gin is, what problems it solves, and how it can help your project.
 
-Or, if you are ready to use Gin in to your project, visit the [Quickstart](https://gin-gonic.com/docs/quickstart/).
+Or, if you are ready to use Gin in to your project, visit the [Quickstart](https://gin-gonic.com/en/docs/quickstart/).
 
 ## Features
 


### PR DESCRIPTION
Fix https://github.com/gin-gonic/gin/issues/4214#issue-2991674019

Change URI from `https://gin-gonic.com/docs/quickstart/` to `https://gin-gonic.com/en/docs/quickstart/`

A simple fix—though there may be a more elegant solution for all supported languages.