### PR TITLE
Graceful shutdown example waits needlessly

### DIFF
--- a/src/content/docs/en/docs/examples/graceful-restart-or-stop.md
+++ b/src/content/docs/en/docs/examples/graceful-restart-or-stop.md
@@ -74,9 +74,6 @@ func main() {
 	if err := srv.Shutdown(ctx); err != nil {
 		log.Println("Server Shutdown:", err)
 	}
-	// catching ctx.Done(). timeout of 5 seconds.
-	<-ctx.Done()
-	log.Println("timeout of 5 seconds.")
 	log.Println("Server exiting")
 }
 ```


### PR DESCRIPTION
The previous version would always delay shutdown by 5 seconds, even when `Shutdown()` would return early because shutdown was complete. This change brings it in line with other examples, e.g. https://github.com/gin-gonic/examples/blob/master/graceful-shutdown/graceful-shutdown/notify-without-context/server.go .