### PR TITLE
fix: remove unintended characters ([BS], [RS]) causing broken text in docs

### DIFF
--- a/src/content/docs/ko-kr/docs/examples/bind-single-binary-with-template.md
+++ b/src/content/docs/ko-kr/docs/examples/bind-single-binary-with-template.md
@@ -2,7 +2,7 @@
 title: "템플릿을 포함한 단일 바이너리 빌드"
 ---
 
-[go-assets](https://github.com/jessevdk/go-assets)를 사용하여 템플릿을 포함한 단일 바이너리로 서버를 만들 수 있습니다.
+[go-assets](https://github.com/jessevdk/go-assets)를 사용하여 템플릿을 포함한 단일 바이너리로 서버를 만들 수 있습니다.
 
 ```go
 func main() {

--- a/src/content/docs/ko-kr/docs/examples/binding-and-validation.md
+++ b/src/content/docs/ko-kr/docs/examples/binding-and-validation.md
@@ -12,7 +12,7 @@ Gin은 유효성 검사에 [**go-playground/validator/v10**](https://github.com/
 
 - **타입** - Must bind
   - **메소드** - `Bind`, `BindJSON`, `BindXML`, `BindQuery`, `BindYAML`
-  - **동작** - 이 메소드들은 내부에서 `MustBindWith`를 사용합니다. 바인딩 에러가 있는 경우, 리퀘스트는 `c.AbortWithError(400, err).SetType(ErrorTypeBind)`와 함께 중단됩니다. 응답코드는 400으로 설정되며, `Content-Type`헤더에는 `text/plain; charset=utf-8`이 설정됩니다. 이 이후에 응답코드를 설정하려고 하면 `[GIN-debug] [WARNING] Headers were already written. Wanted to override status code 400 with 422` 경고가 발생합니다. 동작을 더 상세하게 제어하고 싶다면 `ShouldBind`와 같은 메소드를 사용하세요.
+  - **동작** - 이 메소드들은 내부에서 `MustBindWith`를 사용합니다. 바인딩 에러가 있는 경우, 리퀘스트는 `c.AbortWithError(400, err).SetType(ErrorTypeBind)`와 함께 중단됩니다. 응답코드는 400으로 설정되며, `Content-Type`헤더에는 `text/plain; charset=utf-8`이 설정됩니다. 이 이후에 응답코드를 설정하려고 하면 `[GIN-debug] [WARNING] Headers were already written. Wanted to override status code 400 with 422` 경고가 발생합니다. 동작을 더 상세하게 제어하고 싶다면 `ShouldBind`와 같은 메소드를 사용하세요.
 - **타입** - Should bind
   - **메소드** - `ShouldBind`, `ShouldBindJSON`, `ShouldBindXML`, `ShouldBindQuery`, `ShouldBindYAML`
   - **동작** - 이 메소드들은 내부에서 `ShouldBindWith`를 사용합니다. 바인딩 에러가 있는 경우, 에러를 적절히 처리하고 반환하는 것은 개발자의 몫입니다.

--- a/src/content/docs/ko-kr/docs/examples/upload-file/multiple-file.md
+++ b/src/content/docs/ko-kr/docs/examples/upload-file/multiple-file.md
@@ -7,10 +7,10 @@ title: "여러 파일"
 ```go
 func main() {
 	router := gin.Default()
-	// 멀티파트 폼에 대한 최저 메모리 설정 (기본값 32 MiB)
+	// 멀티파트 폼에 대한 최저 메모리 설정 (기본값 32 MiB)
 	router.MaxMultipartMemory = 8 << 20  // 8 MiB
 	router.POST("/upload", func(c *gin.Context) {
-		// 멀티파트 폼
+		// 멀티파트 폼
 		form, _ := c.MultipartForm()
 		files := form.File["upload[]"]
 

--- a/src/content/docs/ko-kr/docs/examples/upload-file/single-file.md
+++ b/src/content/docs/ko-kr/docs/examples/upload-file/single-file.md
@@ -11,7 +11,7 @@ title: "단일 파일"
 ```go
 func main() {
 	router := gin.Default()
-	// 멀티파트 폼에 대한 최저 메모리 설정 (기본값 32 MiB)
+	// 멀티파트 폼에 대한 최저 메모리 설정 (기본값 32 MiB)
 	router.MaxMultipartMemory = 8 << 20  // 8 MiB
 	router.POST("/upload", func(c *gin.Context) {
 		// 단일 파일


### PR DESCRIPTION
### Summary
Removed unexpected characters like [BS] (Backspace) and [RS] (Record Separator) that caused text to appear broken in the documentation.

### Why
These characters were likely added by mistake (e.g., copy-paste or encoding issues) and appeared as broken symbols in rendered text, especially on certain operating systems like Windows.

### Changes
- Removed [BS], [RS] from doc files
- No changes to actual content 