### PR TITLE
docs: fix gin install instructions

### DIFF
--- a/src/content/docs/en/docs/quickstart/index.md
+++ b/src/content/docs/en/docs/quickstart/index.md
@@ -21,12 +21,6 @@ If you don't have a go.mod file, create it with `go mod init gin`.
 go get -u github.com/gin-gonic/gin
 ```
 
-Or install:
-
-```sh
-go install github.com/gin-gonic/gin@latest
-```
-
 2. Import it in your code:
 
 ```go


### PR DESCRIPTION
### What I have done?
Remove the line of installing gin by `go install` .

### Why?
It's strange to use `go install` to install dependecies. So I refer to the [Go Document](https://go.dev/ref/mod#go-install) and it says:

```
The go install command builds and installs the packages named by the paths on the command line. Executables (main packages) are installed to the directory named by the GOBIN environment variable, which defaults to $GOPATH/bin or $HOME/go/bin if the GOPATH environment variable is not set. Executables in $GOROOT are installed in $GOROOT/bin or $GOTOOLDIR instead of $GOBIN. Non-executable packages are built and cached but not installed.
```

`go install` is mainly used to build from source and install executable. Gin is a non-executable pacakge, so the command only downloads the source code and does nothing. This is the actual output:
```
% go install github.com/gin-gonic/gin@latest
go: downloading github.com/gin-gonic/gin v1.10.0
go: downloading github.com/mattn/go-isatty v0.0.20
go: downloading github.com/gin-contrib/sse v0.1.0
go: downloading golang.org/x/net v0.25.0
go: downloading github.com/go-playground/validator/v10 v10.20.0
go: downloading github.com/pelletier/go-toml/v2 v2.2.2
go: downloading github.com/ugorji/go/codec v1.2.12
go: downloading google.golang.org/protobuf v1.34.1
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading golang.org/x/sys v0.20.0
go: downloading golang.org/x/text v0.15.0
go: downloading golang.org/x/crypto v0.23.0
go: downloading github.com/gabriel-vasile/mimetype v1.4.3
go: downloading github.com/leodido/go-urn v1.4.0
go: downloading github.com/go-playground/universal-translator v0.18.1
go: downloading github.com/go-playground/locales v0.14.1
package github.com/gin-gonic/gin is not a main package
```
**The command wouldn't update `go.mod`**, so I still have to run `go get` or `go mod tidy` after import to update `go.mod` file.  `go get` downloads the source code and updates the `go.mod` file at once, so it' enough to use `go get` only.

Anyway, this is a quickstart for beginners, I think it doesn't help at all.
