### PR TITLE
docs(id): Add Indonesian (id) translation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -36,6 +36,10 @@ export default defineConfig({
                 label: "Persian",
                 lang: "fa",
             },
+            "id": {
+                label: "Bahasa Indonesia",
+                lang: "id",
+            },
             "ja": {
                 label: "日本語",
                 lang: "ja",

--- a/src/content/docs/id/docs/benchmarks/index.md
+++ b/src/content/docs/id/docs/benchmarks/index.md
@@ -1,0 +1,117 @@
+---
+title: "Benchmarks"
+sidebar:
+  order: 3
+---
+
+**HOST VM:** Travis
+**Mesin:** Ubuntu 16.04.6 LTS x64
+**Tanggal:** 04 Mei 2020
+**Versi:** Gin v1.6.3
+**Versi Go:** 1.14.2 linux/amd64
+**Sumber:** [Go HTTP Router Benchmark](https://github.com/gin-gonic/go-http-routing-benchmark)
+**Hasil:** [Lihat gist](https://gist.github.com/appleboy/b5f2ecfaf50824ae9c64dcfb9165ae5e) atau [hasil Travis](https://travis-ci.org/github/gin-gonic/go-http-routing-benchmark/jobs/682947061)
+
+Gin menggunakan versi custom dari [HttpRouter](https://github.com/julienschmidt/httprouter)
+
+[Lihat semua benchmark](https://github.com/gin-gonic/gin/blob/master/BENCHMARKS.md)
+
+| Test                              | Repetitions | Time (ns/op) | Bytes (B/op) | Allocations (allocs/op) |
+| --------------------------------- | ----------- | ------------ | ------------ | ----------------------- |
+| BenchmarkGin_GithubStatic         | 15629472    | 76.7         | 0            | 0                       |
+| BenchmarkAce_GithubStatic         | 15542612    | 75.9         | 0            | 0                       |
+| BenchmarkAero_GithubStatic        | 24777151    | 48.5         | 0            | 0                       |
+| BenchmarkBear_GithubStatic        | 2788894     | 435          | 120          | 3                       |
+| BenchmarkBeego_GithubStatic       | 1000000     | 1064         | 352          | 3                       |
+| BenchmarkBone_GithubStatic        | 93507       | 12838        | 2880         | 60                      |
+| BenchmarkChi_GithubStatic         | 1387743     | 860          | 432          | 3                       |
+| BenchmarkDenco_GithubStatic       | 39384996    | 30.4         | 0            | 0                       |
+| BenchmarkEcho_GithubStatic        | 12076382    | 99.1         | 0            | 0                       |
+| BenchmarkGocraftWeb_GithubStatic  | 1596495     | 756          | 296          | 5                       |
+| BenchmarkGoji_GithubStatic        | 6364876     | 189          | 0            | 0                       |
+| BenchmarkGojiv2_GithubStatic      | 550202      | 2098         | 1312         | 10                      |
+| BenchmarkGoRestful_GithubStatic   | 102183      | 12552        | 4256         | 13                      |
+| BenchmarkGoJsonRest_GithubStatic  | 1000000     | 1029         | 329          | 11                      |
+| BenchmarkGorillaMux_GithubStatic  | 255552      | 5190         | 976          | 9                       |
+| BenchmarkGowwwRouter_GithubStatic | 15531916    | 77.1         | 0            | 0                       |
+| BenchmarkHttpRouter_GithubStatic  | 27920724    | 43.1         | 0            | 0                       |
+| BenchmarkHttpTreeMux_GithubStatic | 21448953    | 55.8         | 0            | 0                       |
+| BenchmarkKocha_GithubStatic       | 21405310    | 56.0         | 0            | 0                       |
+| BenchmarkLARS_GithubStatic        | 13625156    | 89.0         | 0            | 0                       |
+| BenchmarkMacaron_GithubStatic     | 1000000     | 1747         | 736          | 8                       |
+| BenchmarkMartini_GithubStatic     | 187186      | 7326         | 768          | 9                       |
+| BenchmarkPat_GithubStatic         | 109143      | 11563        | 3648         | 76                      |
+| BenchmarkPossum_GithubStatic      | 1575898     | 770          | 416          | 3                       |
+| BenchmarkR2router_GithubStatic    | 3046231     | 404          | 144          | 4                       |
+| BenchmarkRivet_GithubStatic       | 11484826    | 105          | 0            | 0                       |
+| BenchmarkTango_GithubStatic       | 1000000     | 1153         | 248          | 8                       |
+| BenchmarkTigerTonic_GithubStatic  | 4929780     | 249          | 48           | 1                       |
+| BenchmarkTraffic_GithubStatic     | 106351      | 11819        | 4664         | 90                      |
+| BenchmarkVulcan_GithubStatic      | 1613271     | 722          | 98           | 3                       |
+| BenchmarkAce_GithubParam          | 8386032     | 143          | 0            | 0                       |
+| BenchmarkAero_GithubParam         | 11816200    | 102          | 0            | 0                       |
+| BenchmarkBear_GithubParam         | 1000000     | 1012         | 496          | 5                       |
+| BenchmarkBeego_GithubParam        | 1000000     | 1157         | 352          | 3                       |
+| BenchmarkBone_GithubParam         | 184653      | 6912         | 1888         | 19                      |
+| BenchmarkChi_GithubParam          | 1000000     | 1102         | 432          | 3                       |
+| BenchmarkDenco_GithubParam        | 3484798     | 352          | 128          | 1                       |
+| BenchmarkEcho_GithubParam         | 6337380     | 189          | 0            | 0                       |
+| BenchmarkGin_GithubParam          | 9132032     | 131          | 0            | 0                       |
+| BenchmarkGocraftWeb_GithubParam   | 1000000     | 1446         | 712          | 9                       |
+| BenchmarkGoji_GithubParam         | 1248640     | 977          | 336          | 2                       |
+| BenchmarkGojiv2_GithubParam       | 383233      | 2784         | 1408         | 13                      |
+| BenchmarkGoJsonRest_GithubParam   | 1000000     | 1991         | 713          | 14                      |
+| BenchmarkGoRestful_GithubParam    | 76414       | 16015        | 4352         | 16                      |
+| BenchmarkGorillaMux_GithubParam   | 150026      | 7663         | 1296         | 10                      |
+| BenchmarkGowwwRouter_GithubParam  | 1592044     | 751          | 432          | 3                       |
+| BenchmarkHttpRouter_GithubParam   | 10420628    | 115          | 0            | 0                       |
+| BenchmarkHttpTreeMux_GithubParam  | 1403755     | 835          | 384          | 4                       |
+| BenchmarkKocha_GithubParam        | 2286170     | 533          | 128          | 5                       |
+| BenchmarkLARS_GithubParam         | 9540374     | 129          | 0            | 0                       |
+| BenchmarkMacaron_GithubParam      | 533154      | 2742         | 1072         | 10                      |
+| BenchmarkMartini_GithubParam      | 119397      | 9638         | 1152         | 11                      |
+| BenchmarkPat_GithubParam          | 150675      | 8858         | 2408         | 48                      |
+| BenchmarkPossum_GithubParam       | 1000000     | 1001         | 496          | 5                       |
+| BenchmarkR2router_GithubParam     | 1602886     | 761          | 432          | 5                       |
+| BenchmarkRivet_GithubParam        | 2986579     | 409          | 96           | 1                       |
+| BenchmarkTango_GithubParam        | 1000000     | 1356         | 344          | 8                       |
+| BenchmarkTigerTonic_GithubParam   | 388899      | 3429         | 1176         | 22                      |
+| BenchmarkTraffic_GithubParam      | 123160      | 9734         | 2816         | 40                      |
+| BenchmarkVulcan_GithubParam       | 1000000     | 1138         | 98           | 3                       |
+| BenchmarkAce_GithubAll            | 40543       | 29670        | 0            | 0                       |
+| BenchmarkAero_GithubAll           | 57632       | 20648        | 0            | 0                       |
+| BenchmarkBear_GithubAll           | 9234        | 216179       | 86448        | 943                     |
+| BenchmarkBeego_GithubAll          | 7407        | 243496       | 71456        | 609                     |
+| BenchmarkBone_GithubAll           | 420         | 2922835      | 720160       | 8620                    |
+| BenchmarkChi_GithubAll            | 7620        | 238331       | 87696        | 609                     |
+| BenchmarkDenco_GithubAll          | 18355       | 64494        | 20224        | 167                     |
+| BenchmarkEcho_GithubAll           | 31251       | 38479        | 0            | 0                       |
+| BenchmarkGin_GithubAll            | 43550       | 27364        | 0            | 0                       |
+| BenchmarkGocraftWeb_GithubAll     | 4117        | 300062       | 131656       | 1686                    |
+| BenchmarkGoji_GithubAll           | 3274        | 416158       | 56112        | 334                     |
+| BenchmarkGojiv2_GithubAll         | 1402        | 870518       | 352720       | 4321                    |
+| BenchmarkGoJsonRest_GithubAll     | 2976        | 401507       | 134371       | 2737                    |
+| BenchmarkGoRestful_GithubAll      | 410         | 2913158      | 910144       | 2938                    |
+| BenchmarkGorillaMux_GithubAll     | 346         | 3384987      | 251650       | 1994                    |
+| BenchmarkGowwwRouter_GithubAll    | 10000       | 143025       | 72144        | 501                     |
+| BenchmarkHttpRouter_GithubAll     | 55938       | 21360        | 0            | 0                       |
+| BenchmarkHttpTreeMux_GithubAll    | 10000       | 153944       | 65856        | 671                     |
+| BenchmarkKocha_GithubAll          | 10000       | 106315       | 23304        | 843                     |
+| BenchmarkLARS_GithubAll           | 47779       | 25084        | 0            | 0                       |
+| BenchmarkMacaron_GithubAll        | 3266        | 371907       | 149409       | 1624                    |
+| BenchmarkMartini_GithubAll        | 331         | 3444706      | 226551       | 2325                    |
+| BenchmarkPat_GithubAll            | 273         | 4381818      | 1483152      | 26963                   |
+| BenchmarkPossum_GithubAll         | 10000       | 164367       | 84448        | 609                     |
+| BenchmarkR2router_GithubAll       | 10000       | 160220       | 77328        | 979                     |
+| BenchmarkRivet_GithubAll          | 14625       | 82453        | 16272        | 167                     |
+| BenchmarkTango_GithubAll          | 6255        | 279611       | 63826        | 1618                    |
+| BenchmarkTigerTonic_GithubAll     | 2008        | 687874       | 193856       | 4474                    |
+| BenchmarkTraffic_GithubAll        | 355         | 3478508      | 820744       | 14114                   |
+| BenchmarkVulcan_GithubAll         | 6885        | 193333       | 19894        | 609                     |
+
+Catatan:
+
+- Repetitions: Total pengulangan yang dicapai dalam waktu konstan, semakin tinggi berarti hasil semakin meyakinkan
+- Time: Durasi per pengulangan tunggal (ns/op), semakin rendah semakin baik
+- Bytes: Memori heap (B/op), semakin rendah semakin baik
+- Allocations: Rata-rata alokasi per pengulangan (allocs/op), semakin rendah semakin baik

--- a/src/content/docs/id/docs/deployment/index.md
+++ b/src/content/docs/id/docs/deployment/index.md
@@ -1,0 +1,146 @@
+---
+title: "Deployment"
+sidebar:
+  order: 6
+---
+
+Proyek Gin dapat di-deploy dengan mudah di penyedia cloud apa pun.
+
+## [Railway](https://www.railway.com)
+
+Railway adalah platform pengembangan cloud canggih untuk men-deploy, mengelola, dan penskalaan aplikasi serta service. Platform ini menyederhanakan stack infrastruktur Anda, dari server hingga observabilitas dalam satu platform yang dapat diskalakan dan mudah digunakan.
+
+Ikuti [panduan dari Railway untuk men-deploy proyek Gin Anda](https://docs.railway.com/guides/gin).
+
+## [Koyeb](https://www.koyeb.com)
+
+Koyeb adalah platform serverless yang ramah developer untuk men-deploy aplikasi secara global, dengan deployment berbasis Git, enkripsi TLS, autoscaling bawaan, jaringan edge global, serta service mesh & discovery terintegrasi.
+
+Ikuti [panduan dari Koyeb untuk men-deploy proyek Gin Anda](https://www.koyeb.com/tutorials/deploy-go-gin-on-koyeb).
+
+## [Qovery](https://www.qovery.com)
+
+Qovery menyediakan hosting Cloud gratis dengan database, SSL, CDN global, dan deploy otomatis dengan Git.
+
+Ikuti [panduan Qovery untuk men-deploy proyek Gin Anda](https://docs.qovery.com/guides/tutorial/deploy-gin-with-postgresql/).
+
+## [Render](https://render.com)
+
+Render adalah platform cloud modern yang menawarkan dukungan native untuk Go, SSL yang terkelola penuh, database, deploy zero-downtime, HTTP/2, dan dukungan websocket.
+
+Ikuti [panduan dari Render untuk men-deploy proyek Gin Anda](https://render.com/docs/deploy-go-gin).
+
+## [Google App Engine](https://cloud.google.com/appengine/)
+
+GAE memiliki dua cara untuk men-deploy aplikasi Go. Lingkungan standar lebih mudah digunakan, tetapi kustomisasinya lebih terbatas dan mencegah [syscalls](https://github.com/gin-gonic/gin/issues/1639) untuk alasan keamanan. Lingkungan fleksibel dapat menjalankan framework atau library apa pun.
+
+Pelajari lebih lanjut dan pilih lingkungan sesuai preferensi Anda di [Go on Google App Engine](https://cloud.google.com/appengine/docs/go/).
+
+## Self Hosted
+
+Proyek Gin juga dapat di-deploy secara mandiri. Arsitektur deployment dan aspek keamanan bervariasi, tergantung pada lingkungan target. Bagian berikut hanya menyajikan gambaran umum tentang opsi konfigurasi yang perlu dipertimbangkan saat merencanakan deployment.
+
+## Opsi Konfigurasi
+
+Deployment proyek Gin dapat disesuaikan menggunakan variabel lingkungan atau langsung di dalam kode.
+
+Berikut variabel lingkungan yang tersedia untuk mengonfigurasi Gin:
+
+| Variabel Lingkungan | Deskripsi                                                                                                                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| PORT                 | Port TCP yang akan digunakan saat memulai server Gin dengan `router.Run()` (tanpa argumen apa pun).                                                                                                      |
+| GIN_MODE             | Atur ke salah satu dari `debug`, `release`, atau `test`. Mengelola mode Gin, seperti kapan harus menampilkan output debug. Dapat juga diatur dalam kode menggunakan `gin.SetMode(gin.ReleaseMode)` atau `gin.SetMode(gin.TestMode)` |
+
+Kode berikut dapat digunakan untuk mengonfigurasi Gin.
+
+```go
+// Tanpa menentukan alamat bind atau port untuk Gin. Secara bawaan akan mengikat pada semua interface di port 8080.
+// Anda juga dapat menggunakan variabel lingkungan PORT untuk mengubah listen port saat menggunakan Run() tanpa argumen apa pun.
+router := gin.Default()
+router.Run()
+
+// Secara eksplisit menentukan alamat bind dan port binding
+router := gin.Default()
+router.Run("192.168.1.100:8080")
+
+// Hanya secara eksplisit menentukan listen port. Akan mengikat pada semua interface.
+router := gin.Default()
+router.Run(":8080")
+
+// Tentukan alamat IP atau CIDR mana yang dianggap tepercaya untuk mengatur header untuk mendokumentasikan alamat IP asli klien.
+// Lihat dokumentasi untuk detail lebih lanjut.
+router := gin.Default()
+router.SetTrustedProxies([]string{"192.168.1.2"})
+```
+
+## Jangan percayai semua proksi
+
+Gin memungkinkan Anda menentukan header mana saja yang akan menyimpan IP asli klien (jika ada),
+serta menentukan proksi (atau klien langsung) mana yang Anda percayai untuk
+menentukan salah satu dari header tersebut.
+
+Gunakan fungsi `SetTrustedProxies()` pada `gin.Engine` Anda untuk menentukan alamat jaringan
+atau CIDR mana saja yang dapat dipercaya untuk header permintaan terkait IP klien.
+Nilainya dapat berupa alamat IPv4, CIDR IPv4, alamat IPv6, atau +CIDR IPv6.
+
+**Perhatian:** Secara bawaan Gin memercayai semua proksi jika Anda tidak menentukan proxy tepercaya secara eksplisit
+menggunakan fungsi di atas, **hal ini TIDAK aman**. Di sisi lain, jika Anda tidak
+menggunakan proxy apa pun, Anda dapat menonaktifkan fitur ini dengan menggunakan `Engine.SetTrustedProxies(nil)`,
+sehingga `Context.ClientIP()` akan langsung mengembalikan alamat remote untuk menghindari
+komputasi yang tidak perlu.
+
+```go
+import (
+  "fmt"
+
+  "github.com/gin-gonic/gin"
+)
+
+func main() {
+  router := gin.Default()
+  router.SetTrustedProxies([]string{"192.168.1.2"})
+
+  router.GET("/", func(c *gin.Context) {
+    // Jika klien adalah 192.168.1.2, gunakan header X-Forwarded-For
+    // untuk menentukan IP asli klien dari bagian-bagian header
+    // yang terpercaya.
+    // Jika tidak, kembalikan langsung IP klien.
+    fmt.Printf("ClientIP: %s\n", c.ClientIP())
+  })
+  router.Run()
+}
+```
+
+**Perhatian:** Jika Anda menggunakan layanan CDN, Anda dapat mengatur `Engine.TrustedPlatform`
+untuk melewati pemeriksaan TrustedProxies, karena memiliki prioritas lebih tinggi daripada TrustedProxies.
+Lihat contoh di bawah ini:
+
+```go
+import (
+  "fmt"
+
+  "github.com/gin-gonic/gin"
+)
+
+func main() {
+  router := gin.Default()
+  // Gunakan header yang telah ditentukan sebelumnya gin.PlatformXXX
+  // Google App Engine
+  router.TrustedPlatform = gin.PlatformGoogleAppEngine
+  // Cloudflare
+  router.TrustedPlatform = gin.PlatformCloudflare
+  // Fly.io
+  router.TrustedPlatform = gin.PlatformFlyIO
+  // Atau, Anda dapat mengatur header permintaan tepercaya Anda sendiri. Namun, pastikan CDN Anda
+  // mencegah pengguna mengirimkan header ini! Misalnya, jika CDN Anda menempatkan
+  // IP klien di X-CDN-Client-IP:
+  router.TrustedPlatform = "X-CDN-Client-IP"
+
+  router.GET("/", func(c *gin.Context) {
+    // Jika Anda mengatur TrustedPlatform, ClientIP() akan menyelesaikan
+    // header yang sesuai dan mengembalikan IP secara langsung.
+    fmt.Printf("ClientIP: %s\n", c.ClientIP())
+  })
+  router.Run()
+}
+```

--- a/src/content/docs/id/docs/encoding/index.md
+++ b/src/content/docs/id/docs/encoding/index.md
@@ -1,0 +1,27 @@
+---
+title: "Encoding"
+sidebar:
+  order: 5
+---
+
+### Build dengan pengganti json
+
+Gin menggunakan `encoding/json` sebagai paket JSON bawaan, tetapi Anda dapat mengubahnya dengan melakukan build dari tag lain.
+
+[go-json](https://github.com/goccy/go-json)
+
+```sh
+go build -tags=go_json .
+```
+
+[jsoniter](https://github.com/json-iterator/go)
+
+```sh
+go build -tags=jsoniter .
+```
+
+[sonic](https://github.com/bytedance/sonic) (Anda harus memastikan bahwa CPU Anda mendukung instruksi AVX.)
+
+```sh
+$ go build -tags="sonic avx" .
+```

--- a/src/content/docs/id/docs/examples/index.md
+++ b/src/content/docs/id/docs/examples/index.md
@@ -1,0 +1,7 @@
+---
+title: "Contoh"
+sidebar:
+  order: 6
+---
+
+Bagian ini berisi contoh penggunaan API.

--- a/src/content/docs/id/docs/faq/index.md
+++ b/src/content/docs/id/docs/faq/index.md
@@ -1,0 +1,7 @@
+---
+title: "FAQ"
+sidebar:
+  order: 9
+---
+
+TODO: Catat beberapa pertanyaan yang sering diajukan dari tab GitHub Issue.

--- a/src/content/docs/id/docs/features/index.md
+++ b/src/content/docs/id/docs/features/index.md
@@ -1,0 +1,13 @@
+---
+title: "Fitur"
+sidebar:
+  order: 4
+---
+
+## Fitur stabil Gin v1
+
+- Router tanpa alokasi memori.
+- Tetap menjadi router dan framework HTTP tercepat. Dari routing hingga penulisan.
+- Kumpulan unit test yang lengkap.
+- Teruji di lapangan.
+- API stabil, rilis baru tidak akan merusak kode Anda.

--- a/src/content/docs/id/docs/index.md
+++ b/src/content/docs/id/docs/index.md
@@ -1,0 +1,20 @@
+---
+title: "Dokumentasi"
+sidebar:
+  order: 20
+---
+
+## Apa itu Gin?
+
+Gin adalah framework web yang ditulis menggunakan Go (Golang). Framework ini memiliki API yang mirip dengan Martini, tapi dengan performa hingga 40 kali lebih cepat. Kalau Anda membutuhkan performa tinggi dan produktivitas, Anda akan menyukai Gin.
+
+## Bagaimana cara menggunakan Gin?
+
+Kami menyediakan [contoh](https://github.com/gin-gonic/examples) penggunaan API dan daftar beberapa [pengguna Gin](./users) yang sudah dikenal publik.
+
+## Bagaimana cara berkontribusi pada Gin?
+
+- Bantu orang-orang di forum diskusi
+- Ceritakan kisah sukses Anda menggunakan Gin
+- Beritahu kami bagaimana kami dapat meningkatkan Gin dan bantu kami melakukannya
+- Berkontribusi pada library yang sudah ada

--- a/src/content/docs/id/docs/introduction/index.md
+++ b/src/content/docs/id/docs/introduction/index.md
@@ -1,0 +1,45 @@
+---
+title: "Pendahuluan"
+sidebar:
+  order: 1
+---
+
+Gin adalah framework web yang ditulis menggunakan Go (Golang). Framework ini memiliki API yang mirip dengan Martini, tapi dengan performa hingga 40 kali lebih cepat berkat [httprouter](https://github.com/julienschmidt/httprouter). Kalau Anda membutuhkan performa tinggi dan produktivitas, Anda akan menyukai Gin.
+
+Di bagian ini kita akan membahas apa itu Gin, masalah apa yang dapat diselesaikannya, dan bagaimana Gin dapat membantu proyek Anda.
+
+Atau, jika Anda sudah siap menggunakan Gin di proyek Anda, kunjungi [Quickstart](../quickstart/).
+
+## Fitur
+
+### Cepat
+
+Routing berbasis radix tree, memori footprint kecil. Tidak ada penggunaan reflection. Kinerja API yang dapat diprediksi.
+
+### Dukungan middleware
+
+Permintaan HTTP yang masuk dapat diproses oleh serangkaian middleware sebelum tindakan akhirnya dieksekusi. Sebagai contoh: Logger, Authorization, GZIP, dan selanjutnya pesan disimpan ke dalam DB.
+
+### Bebas crash
+
+Gin dapat menangkap dan memulihkan panic yang terjadi selama pemrosesan permintaan HTTP. Dengan begitu, server Anda akan selalu tersedia. Panic ini juga dapat dilaporkan ke layanan seperti Sentry!
+
+### Validasi JSON
+
+Gin dapat melakukan parse dan validasi JSON dari suatu permintaan, seperti memeriksa keberadaan nilai yang wajib diisi.
+
+### Pengelompokan route
+
+Atur route dengan lebih rapi. Anda bisa mengelompokkan route yang memerlukan otorisasi dan yang tidak, atau berdasarkan versi API yang berbeda. Pengelompokan ini bisa bersarang tanpa batas dan tidak akan menurunkan performa.
+
+### Manajemen error
+
+Gin menyediakan cara yang mudah untuk mengumpulkan semua error yang terjadi selama pemrosesan permintaan HTTP. Nantinya, middleware dapat mencatat error tersebut ke file log, database, dan mengirimnya melalui jaringan.
+
+### Rendering bawaan
+
+Gin menyediakan API yang mudah digunakan untuk melakukan rendering dalam format JSON, XML, dan HTML.
+
+### Extendable
+
+Sangat mudah membuat middleware baru, Anda bisa langsung melihat contoh kodenya.

--- a/src/content/docs/id/docs/quickstart/index.md
+++ b/src/content/docs/id/docs/quickstart/index.md
@@ -1,0 +1,113 @@
+---
+title: "Quickstart"
+sidebar:
+  order: 2
+---
+
+Pada quickstart ini, kita akan mendapatkan pengetahuan dari beberapa contoh kode dan belajar caranya:
+
+## Persyaratan
+
+- Go 1.16 atau di atasnya
+
+## Instalasi
+
+Untuk menginstal paket Gin, Anda perlu menginstal Go dan mengatur workspace Go Anda terlebih dahulu.
+Jika Anda belum memiliki file go.mod, buat dengan `go mod init gin`.
+
+1. Unduh dan instal:
+
+```sh
+go get -u github.com/gin-gonic/gin
+```
+
+2. Impor di dalam kode Anda:
+
+```go
+import "github.com/gin-gonic/gin"
+```
+
+3. (Opsional) Impor `net/http`. Ini diperlukan, misalnya jika menggunakan konstanta seperti `http.StatusOK`.
+
+```go
+import "net/http"
+```
+
+4. Buat folder proyek Anda dan masuk ke dalamnya dengan `cd`
+
+```sh
+mkdir -p project && cd "$_"
+```
+
+5. Salin template awal ke dalam proyek Anda
+
+```sh
+curl https://raw.githubusercontent.com/gin-gonic/examples/master/basic/main.go > main.go
+```
+
+6. Jalankan proyek Anda
+
+```sh
+go run main.go
+```
+
+## Memulai
+
+> Tidak tahu cara menulis dan menjalankan kode Go? [Klik di sini](https://golang.org/doc/code.html).
+
+Pertama, buat file `example.go`:
+
+```sh
+# asumsikan kode berikut ada di dalam file example.go
+$ touch example.go
+```
+
+Selanjutnya, masukkan kode berikut ke dalam `example.go`:
+
+```go
+package main
+
+import "github.com/gin-gonic/gin"
+
+func main() {
+  router := gin.Default()
+  router.GET("/ping", func(c *gin.Context) {
+    c.JSON(200, gin.H{
+      "message": "pong",
+    })
+  })
+  router.Run() // jalankan server pada 0.0.0.0:8080
+}
+```
+
+Dan, Anda dapat menjalankan kode melalui `go run example.go`:
+
+```sh
+# jalankan example.go dan kunjungi 0.0.0.0:8080/ping di browser
+$ go run example.go
+```
+
+Jika Anda lebih memilih untuk menggunakan paket `net/http`, ikuti contoh kode di bawah ini
+
+```go
+package main
+
+import (
+  "github.com/gin-gonic/gin"
+  "net/http"
+)
+
+func main() {
+  router := gin.Default()
+
+  router.GET("/ping", func(c *gin.Context) {
+    c.JSON(http.StatusOK, gin.H{
+      "message": "pong",
+    })
+  })
+
+  router.Run() // jalankan server pada 0.0.0.0:8080
+}
+```
+
+Informasi tambahan tersedia di [repositori kode sumber Gin](https://github.com/gin-gonic/gin/blob/master/docs/doc.md).

--- a/src/content/docs/id/docs/testing/index.md
+++ b/src/content/docs/id/docs/testing/index.md
@@ -1,0 +1,91 @@
+---
+title: "Pengujian"
+sidebar:
+  order: 7
+---
+
+## Cara menulis test case di Gin
+
+`net/http/httptest` adalah paket yang lebih disukai untuk pengujian HTTP.
+
+```go
+package main
+
+import "github.com/gin-gonic/gin"
+
+type User struct {
+  Username string `json:"username"`
+  Gender   string `json:"gender"`
+}
+
+func setupRouter() *gin.Engine {
+  router := gin.Default()
+  router.GET("/ping", func(c *gin.Context) {
+    c.String(200, "pong")
+  })
+  return router
+}
+
+func postUser(router *gin.Engine) *gin.Engine {
+  router.POST("/user/add", func(c *gin.Context) {
+    var user User
+    c.BindJSON(&user)
+    c.JSON(200, user)
+  })
+  return router
+}
+
+func main() {
+  router := setupRouter()
+  router = postUser(r)
+  router.Run(":8080")
+}
+```
+
+Contoh pengujian untuk kode di atas:
+
+```go
+package main
+
+import (
+  "net/http"
+  "net/http/httptest"
+  "encoding/json"
+  "testing"
+  "strings"
+
+  "github.com/stretchr/testify/assert"
+)
+
+func TestPingRoute(t *testing.T) {
+  router := setupRouter()
+
+  w := httptest.NewRecorder()
+  req, _ := http.NewRequest("GET", "/ping", nil)
+  router.ServeHTTP(w, req)
+
+  assert.Equal(t, 200, w.Code)
+  assert.Equal(t, "pong", w.Body.String())
+}
+
+// Pengujian untuk POST /user/add
+func TestPostUser(t *testing.T) {
+  router := setupRouter()
+  router = postUser(router)
+
+  w := httptest.NewRecorder()
+
+  // Buat contoh user untuk pengujian
+  exampleUser := User{
+    Username: "test_name",
+    Gender:   "male",
+  }
+  userJson, _ := json.Marshal(exampleUser)
+  req, _ := http.NewRequest("POST", "/user/add", strings.NewReader(string(userJson)))
+  router.ServeHTTP(w, req)
+
+  assert.Equal(t, 200, w.Code)
+  // Bandingkan body respons dengan data json dari exampleUser
+  assert.Equal(t, string(userJson), w.Body.String())
+}
+```

--- a/src/content/docs/id/docs/users/index.md
+++ b/src/content/docs/id/docs/users/index.md
@@ -1,0 +1,15 @@
+---
+title: "Pengguna"
+sidebar:
+  order: 8
+---
+
+## Daftar Proyek Unggulan
+
+- [gorush](https://github.com/appleboy/gorush): Server notifikasi push yang ditulis menggunakan Go.
+- [fnproject](https://github.com/fnproject/fn): Platform serverless berbasis container-native dan agnostik cloud.
+- [photoprism](https://github.com/photoprism/photoprism): Aplikasi Foto Berbasis AI untuk Web Terdesentralisasi.
+- [krakend](https://github.com/devopsfaith/krakend): API Gateway berperforma sangat tinggi dengan middleware.
+- [picfit](https://github.com/thoas/picfit): Server pengubah ukuran gambar yang ditulis menggunakan Go.
+- [gotify](https://github.com/gotify/server): Server sederhana untuk mengirim dan menerima pesan secara real-time melalui WebSocket.
+- [cds](https://github.com/ovh/cds): Platform Sumber Terbuka untuk Continuous Delivery & Otomatisasi DevOps Tingkat Enterprise.

--- a/src/content/docs/id/index.mdx
+++ b/src/content/docs/id/index.mdx
@@ -1,0 +1,50 @@
+---
+title: Gin Web Framework
+description: The fastest full-featured web framework for Go. Crystal clear.
+template: splash
+hero:
+  tagline: Framework web Go tercepat dengan fitur lengkap. Jelas seperti kristal.
+  image:
+    file: ../../../assets/gin.png
+  actions:
+    - text: Baca dokumentasi
+      link: /id/docs/
+      icon: right-arrow
+    - text: Unduh
+      link: https://github.com/gin-gonic/gin/releases
+      icon: external
+      variant: minimal
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+## Apa itu Gin?
+
+Gin adalah framework web yang ditulis menggunakan Golang. Framework ini memiliki API yang mirip dengan Martini, tapi dengan performa hingga 40 kali lebih cepat. Kalau Anda membutuhkan performa tinggi dan produktivitas, Anda akan menyukai Gin.
+
+<CardGrid>
+	<Card title="Cepat" icon="rocket">
+		Routing berbasis radix tree, memori footprint kecil. Tidak ada penggunaan reflection. Kinerja API yang dapat diprediksi.
+	</Card>
+	<Card title="Dukungan middleware" icon="seti:plan">
+		Permintaan HTTP yang masuk dapat diproses oleh serangkaian middleware sebelum tindakan akhirnya dieksekusi. Sebagai contoh: Logger, Authorization, GZIP, dan selanjutnya pesan disimpan ke dalam database.
+	</Card>
+	<Card title="Bebas crash" icon="seti:lock">
+		Gin dapat menangkap dan memulihkan panic yang terjadi selama pemrosesan permintaan HTTP. Dengan begitu, server Anda akan selalu tersedia. Bahkan, Anda bisa melaporkan panic ini ke layanan seperti Sentry!
+	</Card>
+	<Card title="Validasi JSON" icon="approve-check-circle">
+		Gin dapat melakukan parse dan validasi JSON dari suatu permintaan, seperti memeriksa keberadaan nilai-nilai yang wajib ada.
+	</Card>
+	<Card title="Pengelompokan route" icon="puzzle">
+		Atur route dengan lebih rapi. Anda bisa mengelompokkan route yang memerlukan otorisasi dan yang tidak, atau berdasarkan versi API yang berbeda. Pengelompokan ini bisa bersarang tanpa batas dan tidak akan menurunkan performa.
+	</Card>
+	<Card title="Manajemen error" icon="open-book">
+		Gin menyediakan cara yang mudah untuk mengumpulkan semua error yang terjadi selama pemrosesan permintaan HTTP. Nantinya, middleware dapat mencatat error tersebut ke file log, database, dan mengirimnya melalui jaringan.
+	</Card>
+	<Card title="Rendering bawaan" icon="seti:json">
+		Gin menyediakan API yang mudah digunakan untuk melakukan rendering dalam format JSON, XML, dan HTML.
+	</Card>
+	<Card title="Extendable" icon="seti:html">
+		Sangat mudah membuat middleware baru, Anda bisa langsung melihat contoh kodenya.
+	</Card>	
+</CardGrid>

--- a/src/content/docs/id/index.mdx
+++ b/src/content/docs/id/index.mdx
@@ -33,7 +33,7 @@ Gin adalah framework web yang ditulis menggunakan Golang. Framework ini memiliki
 		Gin dapat menangkap dan memulihkan panic yang terjadi selama pemrosesan permintaan HTTP. Dengan begitu, server Anda akan selalu tersedia. Panic ini juga dapat dilaporkan ke layanan seperti Sentry!
 	</Card>
 	<Card title="Validasi JSON" icon="approve-check-circle">
-		Gin dapat melakukan parse dan validasi JSON dari suatu permintaan, seperti memeriksa keberadaan nilai-nilai yang wajib ada.
+		Gin dapat melakukan parse dan validasi JSON dari suatu permintaan, seperti memeriksa keberadaan nilai yang wajib diisi.
 	</Card>
 	<Card title="Pengelompokan route" icon="puzzle">
 		Atur route dengan lebih rapi. Anda bisa mengelompokkan route yang memerlukan otorisasi dan yang tidak, atau berdasarkan versi API yang berbeda. Pengelompokan ini bisa bersarang tanpa batas dan tidak akan menurunkan performa.

--- a/src/content/docs/id/index.mdx
+++ b/src/content/docs/id/index.mdx
@@ -27,7 +27,7 @@ Gin adalah framework web yang ditulis menggunakan Golang. Framework ini memiliki
 		Routing berbasis radix tree, memori footprint kecil. Tidak ada penggunaan reflection. Kinerja API yang dapat diprediksi.
 	</Card>
 	<Card title="Dukungan middleware" icon="seti:plan">
-		Permintaan HTTP yang masuk dapat diproses oleh serangkaian middleware sebelum tindakan akhirnya dieksekusi. Sebagai contoh: Logger, Authorization, GZIP, dan selanjutnya pesan disimpan ke dalam database.
+		Permintaan HTTP yang masuk dapat diproses oleh serangkaian middleware sebelum tindakan akhirnya dieksekusi. Sebagai contoh: Logger, Authorization, GZIP, dan selanjutnya pesan disimpan ke dalam DB.
 	</Card>
 	<Card title="Bebas crash" icon="seti:lock">
 		Gin dapat menangkap dan memulihkan panic yang terjadi selama pemrosesan permintaan HTTP. Dengan begitu, server Anda akan selalu tersedia. Bahkan, Anda bisa melaporkan panic ini ke layanan seperti Sentry!

--- a/src/content/docs/id/index.mdx
+++ b/src/content/docs/id/index.mdx
@@ -30,7 +30,7 @@ Gin adalah framework web yang ditulis menggunakan Golang. Framework ini memiliki
 		Permintaan HTTP yang masuk dapat diproses oleh serangkaian middleware sebelum tindakan akhirnya dieksekusi. Sebagai contoh: Logger, Authorization, GZIP, dan selanjutnya pesan disimpan ke dalam DB.
 	</Card>
 	<Card title="Bebas crash" icon="seti:lock">
-		Gin dapat menangkap dan memulihkan panic yang terjadi selama pemrosesan permintaan HTTP. Dengan begitu, server Anda akan selalu tersedia. Bahkan, Anda bisa melaporkan panic ini ke layanan seperti Sentry!
+		Gin dapat menangkap dan memulihkan panic yang terjadi selama pemrosesan permintaan HTTP. Dengan begitu, server Anda akan selalu tersedia. Panic ini juga dapat dilaporkan ke layanan seperti Sentry!
 	</Card>
 	<Card title="Validasi JSON" icon="approve-check-circle">
 		Gin dapat melakukan parse dan validasi JSON dari suatu permintaan, seperti memeriksa keberadaan nilai-nilai yang wajib ada.


### PR DESCRIPTION
This pull request introduces the documentation translation for the Indonesian language (`id`).

### Summary

The goal of this PR is to make Gin's documentation more accessible to the large and growing community of Go developers in Indonesia. Most of the core documentation pages have been translated.

### Changes Included

- **Locale Configuration**: Added `id` (Bahasa Indonesia) to the list of supported locales in `astro.config.mjs`.
- **Content Translation**: Added a new directory `/src/content/docs/id/` containing the translated markdown files, including:
    - Main landing page (`index.mdx`)
    - Introduction
    - Quickstart
    - Benchmarks
    - Features
    - Encoding
    - Deployment
    - Examples (index page only; specific examples are not yet translated)
    - Testing
    - Users
    - FAQ

Further translations for the specific examples can be added in future PRs. Looking forward to your feedback!
