### PR TITLE
docs(id): Add Indonesian translation for example pages (ascii-json, bind-*)

### DIFF
--- a/src/content/docs/id/docs/examples/ascii-json.md
+++ b/src/content/docs/id/docs/examples/ascii-json.md
@@ -1,0 +1,24 @@
+---
+title: "AsciiJSON"
+---
+
+AsciiJSON digunakan untuk menghasilkan JSON yang hanya mengandung karakter ASCII, karakter non-ASCII akan dikonversi ke bentuk escape.
+
+```go
+func main() {
+	router := gin.Default()
+
+	router.GET("/someJSON", func(c *gin.Context) {
+		data := map[string]interface{}{
+			"lang": "GO语言",
+			"tag":  "<br>",
+		}
+
+		// akan menghasilkan : {"lang":"GO\u8bed\u8a00","tag":"\u003cbr\u003e"}
+		c.AsciiJSON(http.StatusOK, data)
+	})
+
+	// jalankan server pada 0.0.0.0:8080
+	router.Run(":8080")
+}
+```

--- a/src/content/docs/id/docs/examples/bind-body-into-dirrerent-structs.md
+++ b/src/content/docs/id/docs/examples/bind-body-into-dirrerent-structs.md
@@ -1,0 +1,58 @@
+---
+title: "Bind body ke struct yang berbeda"
+---
+
+Metode normal untuk binding body permintaan akan menggunakan `c.Request.Body` dan tidak dapat dipanggil berkali-kali.
+
+```go
+type formA struct {
+  Foo string `json:"foo" xml:"foo" binding:"required"`
+}
+
+type formB struct {
+  Bar string `json:"bar" xml:"bar" binding:"required"`
+}
+
+func SomeHandler(c *gin.Context) {
+  objA := formA{}
+  objB := formB{}
+  // c.ShouldBind ini menggunakan c.Request.Body dan tidak dapat digunakan kembali.
+  if errA := c.ShouldBind(&objA); errA == nil {
+    c.String(http.StatusOK, `the body should be formA`)
+  // Ini akan selalu menghasilkan error karena c.Request.Body sekarang sudah EOF.
+  } else if errB := c.ShouldBind(&objB); errB == nil {
+    c.String(http.StatusOK, `the body should be formB`)
+  } else {
+    ...
+  }
+}
+```
+
+Untuk kasus ini, Anda dapat menggunakan `c.ShouldBindBodyWith`.
+
+```go
+func SomeHandler(c *gin.Context) {
+  objA := formA{}
+  objB := formB{}
+  // Membaca c.Request.Body dan menyimpan hasilnya ke dalam context.
+  if errA := c.ShouldBindBodyWith(&objA, binding.JSON); errA == nil {
+    c.String(http.StatusOK, `the body should be formA`)
+  // Menggunakan kembali body yang tersimpan di dalam context.
+  } else if errB := c.ShouldBindBodyWith(&objB, binding.JSON); errB == nil {
+    c.String(http.StatusOK, `the body should be formB JSON`)
+  // Dapat menerima format lain juga
+  } else if errB2 := c.ShouldBindBodyWith(&objB, binding.XML); errB2 == nil {
+    c.String(http.StatusOK, `the body should be formB XML`)
+  } else {
+    ...
+  }
+}
+```
+
+* `c.ShouldBindBodyWith` menyimpan body ke dalam context sebelum melakukan binding.
+Ini sedikit berdampak pada performa, jadi Anda sebaiknya tidak menggunakan metode ini jika
+Anda hanya memanggil binding sekali saja.
+* Fitur ini hanya untuk beberapa format -- `JSON`, `XML`, `MsgPack`,
+`ProtoBuf`. Untuk format lain, `Query`, `Form`, `FormPost`, `FormMultipart`,
+dapat dipanggil dengan `c.ShouldBind()` berkali-kali tanpa mengganggu performa (lihat [#1341](https://github.com/gin-gonic/gin/pull/1341)).
+

--- a/src/content/docs/id/docs/examples/bind-form-data-request-with-custom-struct.md
+++ b/src/content/docs/id/docs/examples/bind-form-data-request-with-custom-struct.md
@@ -1,0 +1,76 @@
+---
+title: "Bind permintaan form-data dengan struct kustom"
+---
+
+Berikut contoh menggunakan struct kustom:
+
+```go
+type StructA struct {
+    FieldA string `form:"field_a"`
+}
+
+type StructB struct {
+    NestedStruct StructA
+    FieldB string `form:"field_b"`
+}
+
+type StructC struct {
+    NestedStructPointer *StructA
+    FieldC string `form:"field_c"`
+}
+
+type StructD struct {
+    NestedAnonyStruct struct {
+        FieldX string `form:"field_x"`
+    }
+    FieldD string `form:"field_d"`
+}
+
+func GetDataB(c *gin.Context) {
+    var b StructB
+    c.Bind(&b)
+    c.JSON(200, gin.H{
+        "a": b.NestedStruct,
+        "b": b.FieldB,
+    })
+}
+
+func GetDataC(c *gin.Context) {
+    var b StructC
+    c.Bind(&b)
+    c.JSON(200, gin.H{
+        "a": b.NestedStructPointer,
+        "c": b.FieldC,
+    })
+}
+
+func GetDataD(c *gin.Context) {
+    var b StructD
+    c.Bind(&b)
+    c.JSON(200, gin.H{
+        "x": b.NestedAnonyStruct,
+        "d": b.FieldD,
+    })
+}
+
+func main() {
+    router := gin.Default()
+    router.GET("/getb", GetDataB)
+    router.GET("/getc", GetDataC)
+    router.GET("/getd", GetDataD)
+
+    router.Run()
+}
+```
+
+Penggunaan perintah `curl` dan hasilnya:
+
+```bash
+$ curl "http://localhost:8080/getb?field_a=hello&field_b=world"
+{"a":{"FieldA":"hello"},"b":"world"}
+$ curl "http://localhost:8080/getc?field_a=hello&field_c=world"
+{"a":{"FieldA":"hello"},"c":"world"}
+$ curl "http://localhost:8080/getd?field_x=hello&field_d=world"
+{"d":"world","x":{"FieldX":"hello"}}
+```
+

--- a/src/content/docs/id/docs/examples/bind-html-checkbox.md
+++ b/src/content/docs/id/docs/examples/bind-html-checkbox.md
@@ -1,0 +1,48 @@
+---
+title: "Bind kotak centang html"
+---
+
+Lihat [informasi detailnya](https://github.com/gin-gonic/gin/issues/129#issuecomment-124260092)
+
+main.go
+
+```go
+...
+
+type myForm struct {
+    Colors []string `form:"colors[]"`
+}
+
+...
+
+func formHandler(c *gin.Context) {
+    var fakeForm myForm
+    c.ShouldBind(&fakeForm)
+    c.JSON(200, gin.H{"color": fakeForm.Colors})
+}
+
+...
+
+```
+
+form.html
+
+```html
+<form action="/" method="POST">
+    <p>Check some colors</p>
+    <label for="red">Red</label>
+    <input type="checkbox" name="colors[]" value="red" id="red">
+    <label for="green">Green</label>
+    <input type="checkbox" name="colors[]" value="green" id="green">
+    <label for="blue">Blue</label>
+    <input type="checkbox" name="colors[]" value="blue" id="blue">
+    <input type="submit">
+</form>
+```
+
+hasil:
+
+```sh
+{"color":["red","green","blue"]}
+```
+

--- a/src/content/docs/id/docs/examples/bind-query-or-post.md
+++ b/src/content/docs/id/docs/examples/bind-query-or-post.md
@@ -1,0 +1,51 @@
+---
+title: "Bind string kueri atau data post"
+---
+
+Lihat [informasi detailnya](https://github.com/gin-gonic/gin/issues/742#issuecomment-264681292).
+
+```go
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Person struct {
+	Name     string    `form:"name"`
+	Address  string    `form:"address"`
+	Birthday time.Time `form:"birthday" time_format:"2006-01-02" time_utc:"1"`
+}
+
+func main() {
+	route := gin.Default()
+	route.GET("/testing", startPage)
+	route.Run(":8085")
+}
+
+func startPage(c *gin.Context) {
+	var person Person
+	// Jika `GET`, hanya `Form` binding engine (`query`) yang digunakan.
+	// Jika `POST`, pertama akan memeriksa `content-type` untuk `JSON` atau `XML`, kemudian menggunakan `Form` (`form-data`).
+	// Lihat selengkapnya di https://github.com/gin-gonic/gin/blob/master/binding/binding.go#L48
+	err := c.ShouldBind(&person)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	log.Println(person.Name)
+	log.Println(person.Address)
+	log.Println(person.Birthday)
+
+	c.String(200, "Success")
+}
+```
+
+Uji dengan:
+```sh
+$ curl -X GET "localhost:8085/testing?name=appleboy&address=xyz&birthday=1992-03-15"
+```

--- a/src/content/docs/id/docs/examples/bind-single-binary-with-template.md
+++ b/src/content/docs/id/docs/examples/bind-single-binary-with-template.md
@@ -1,0 +1,44 @@
+---
+title: "Build binary tunggal dengan template"
+---
+## Menggunakan paket pihak ketiga
+
+Anda dapat menggunakan paket pihak ketiga untuk build server menjadi binary tunggal yang berisi template dengan menggunakan [go-assets](https://github.com/jessevdk/go-assets).
+
+```go
+func main() {
+	r := gin.New()
+
+	t, err := loadTemplate()
+	if err != nil {
+		panic(err)
+	}
+	router.SetHTMLTemplate(t)
+
+	router.GET("/", func(c *gin.Context) {
+		c.HTML(http.StatusOK, "/html/index.tmpl", nil)
+	})
+	router.Run(":8080")
+}
+
+// loadTemplate memuat template yang disematkan oleh go-assets-builder
+func loadTemplate() (*template.Template, error) {
+	t := template.New("")
+	for name, file := range Assets.Files {
+		if file.IsDir() || !strings.HasSuffix(name, ".tmpl") {
+			continue
+		}
+		h, err := ioutil.ReadAll(file)
+		if err != nil {
+			return nil, err
+		}
+		t, err = t.New(name).Parse(string(h))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return t, nil
+}
+```
+
+Lihat contoh lengkapnya di direktori [assets-in-binary/example01](https://github.com/gin-gonic/examples/tree/master/assets-in-binary/example01).

--- a/src/content/docs/id/docs/examples/bind-uri.md
+++ b/src/content/docs/id/docs/examples/bind-uri.md
@@ -1,0 +1,36 @@
+---
+title: "Bind Uri"
+---
+
+Lihat [informasi detailnya](https://github.com/gin-gonic/gin/issues/846).
+
+```go
+package main
+
+import "github.com/gin-gonic/gin"
+
+type Person struct {
+	ID   string `uri:"id" binding:"required,uuid"`
+	Name string `uri:"name" binding:"required"`
+}
+
+func main() {
+	route := gin.Default()
+	route.GET("/:name/:id", func(c *gin.Context) {
+		var person Person
+		if err := c.ShouldBindUri(&person); err != nil {
+			c.JSON(400, gin.H{"msg": err.Error()})
+			return
+		}
+		c.JSON(200, gin.H{"name": person.Name, "uuid": person.ID})
+	})
+	route.Run(":8088")
+}
+```
+
+Uji dengan:
+
+```sh
+$ curl -v localhost:8088/thinkerou/987fbc97-4bed-5078-9f07-9141ba07c9f3
+$ curl -v localhost:8088/thinkerou/not-uuid
+```


### PR DESCRIPTION
This PR continues the Indonesian translation effort for the documentation, focusing on the `examples` section.

This contribution covers `ascii-json.md` and all `bind-*.md` files:

- `examples/ascii-json.md`
- `examples/bind-body-into-dirrerent-structs.md`
- `examples/bind-form-data-request-with-custom-struct.md`
- `examples/bind-html-checkbox.md`
- `examples/bind-query-or-post.md`
- `examples/bind-single-binary-with-template.md`
- `examples/bind-uri.md`

**Note:**
The typo in `bind-body-into-dirrerent-structs.md` (i.e., "dirrerent" instead of "different") is intentional to maintain consistency with existing file names in other language versions.