### PR TITLE
fix(docs): correct router variable name in custom middleware example

### DIFF
--- a/src/content/docs/en/docs/examples/custom-middleware.md
+++ b/src/content/docs/en/docs/examples/custom-middleware.md
@@ -36,7 +36,7 @@ func main() {
 	})
 
 	// Listen and serve on 0.0.0.0:8080
-	router.Run(":8080")
+	r.Run(":8080")
 }
 ```
 


### PR DESCRIPTION
This pull request corrects a typo in the custom middleware example where the incorrect variable 'router' was used to start the server. 
The variable should be 'r', which is properly initialized using gin.New(). 
This fix prevents a runtime error and ensures the example is accurate and executable.
