### PR TITLE
fix : remove conflicting layout file

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,0 @@
-<head>
-  <link rel="sitemap" href="/sitemap-index.xml" />
-</head>
-
-peper


### PR DESCRIPTION


### The Problem
This PR resolves issue #319 
The search functionality on the production website (gin-gonic.com) was not working. This was caused by a conflicting layout file at `src/layouts/Layout.astro` which was overriding the default Starlight theme's layout. This prevented the necessary scripts and HTML for the search feature from being rendered.

### The Fix

This pull request resolves the issue by deleting the conflicting `src/layouts/Layout.astro` file. This allows the default Starlight layout to be used, which correctly includes the search functionality.

### How I Tested

1.  Deleted the file `src/layouts/Layout.astro`.
2.  Ran `npm run build` to create a production build.
3.  Ran `npm run preview` to serve the production build locally.
4.  Confirmed that the search bar is now fully functional on the local preview.