### PR TITLE
docs(zh-cn): improve translation for encoding section

### DIFF
--- a/src/content/docs/zh-cn/docs/encoding/index.md
+++ b/src/content/docs/zh-cn/docs/encoding/index.md
@@ -1,0 +1,28 @@
+---
+title: "编码"
+sidebar:
+  order: 5
+
+---
+
+### 使用其他JSON库进行构建
+
+Gin默认使用 `encoding/json` 作为JSON处理包，但你可以通过在构建时添加标签(tags)来替换为其他JSON库。
+
+[go-json](https://github.com/goccy/go-json)
+
+```sh
+go build -tags=go_json .
+```
+
+[jsoniter](https://github.com/json-iterator/go)
+
+```sh
+go build -tags=jsoniter .
+```
+
+[sonic](https://github.com/bytedance/sonic) （你需要确保你的CPU支持AVX指令）
+
+```sh
+$ go build -tags="sonic avx" .
+```


### PR DESCRIPTION
This PR updates the Simplified Chinese translation for the encoding section by adding and refining content in the encoding/index.md file.

Changes include:
- Added missing translation for "Build with json replacement"
- Improved clarity and consistency in wording

These improvements help make the Chinese documentation more complete and reader-friendly.

Thank you for maintaining this project and reviewing this PR.