### PR TITLE
docs(ja): adjusting details of translations

### DIFF
--- a/src/content/docs/ja/docs/examples/error-handling-middleware.md
+++ b/src/content/docs/ja/docs/examples/error-handling-middleware.md
@@ -13,8 +13,8 @@ title: エラー制御ミドルウェア
 しかし、こうするのは反復的で、一貫性のないものになりがちです。
 
 これを解決するため、一括で全てのエラーを扱う独自のミドルウェアが使えます。
-このミルドウェアはそれぞれの要求の後に走り、Ginの文脈 (`c.Errors`) に加えられたエラーがないか検査します。
-何か見付けたら、適切な状態コードを持つ、構造化されたJSONの応答を送ります。
+このミルドウェアはそれぞれのリクエストの後に走り、Gin の Context に加えられたエラー (`c.Errors`) がないか検査します。
+何か見付けたら、適切なステータスコードを持つ、構造化されたJSONのレスポンスを送ります。
 
 #### 例
 
@@ -25,17 +25,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// ErrorHandlerはエラーを捕捉し、一貫性のあるJSONのエラー応答を返します
+// ErrorHandlerはエラーを捕捉し、一貫性のあるJSONのエラーレスポンスを返します
 func ErrorHandler() gin.HandlerFunc {
     return func(c *gin.Context) {
-        c.Next() // 工程1：まずは要求を処理。
+        c.Next() // 工程1：まずはリクエストを処理。
 
-        // 工程2：文脈にエラーが加えられていないか判定
+        // 工程2：Contextにエラーが加えられていないか判定
         if len(c.Errors) > 0 {
             // 工程3：最後のエラーを使用
             err := c.Errors.Last().Err
 
-            // 工程4：一般的なエラー伝文で応答
+            // 工程4：一般的なエラーメッセージでレスポンス
             c.JSON(http.StatusInternalServerError, map[string]any{
                 "success": false,
                 "message": err.Error(),
@@ -56,13 +56,13 @@ func main() {
         somethingWentWrong := false
 
         if somethingWentWrong {
-            c.Error(errors.New("something went wrong"))
+            c.Error(errors.New("問題が発生しました"))
             return
         }
 
         c.JSON(http.StatusOK, gin.H{
             "success": true,
-            "message": "Everything is fine!",
+            "message": "上手く行きました！",
         })
     })
 
@@ -70,13 +70,13 @@ func main() {
         somethingWentWrong := true
 
         if somethingWentWrong {
-            c.Error(errors.New("something went wrong"))
+            c.Error(errors.New("問題が発生しました"))
             return
         }
 
         c.JSON(http.StatusOK, gin.H{
             "success": true,
-            "message": "Everything is fine!",
+            "message": "上手く行きました！",
         })
     })
 
@@ -87,12 +87,12 @@ func main() {
 
 #### 拡張
 
-- エラーを状態コードに対応付ける
-- エラーコードを元に個別のエラー応答を生成
+- エラーをステータスコードに対応付ける
+- エラーコードを元に個別のエラーレスポンスを生成
 - ログのエラーを使用
 
 #### エラー制御ミドルウェアの利点
 
 - **一貫性**：全てのエラーが同じ形式に従います
-- **明快なルート**：本質的な仕組みはエラーの書式化とは区別されます
+- **明快なルート**：ビジネスロジックがエラーの書式化とは区別されます
 - **重複の低減**：毎回ハンドラでエラー制御の仕組みを繰り返さなくて良くなります


### PR DESCRIPTION
The following content is a machine translation of the Japanese text that follows.

---

Since this concerns the nuances of Japanese translation, I will describe it in Japanese.

The following words in particular have been revised.

- Translation of “request”: Revised from ‘要求’ to “リクエスト.” This was judged to be understandable as a general noun.
- Translation of “response”: Revised from ‘応答’ to “レスポンス.” This was judged to be understandable as a general noun.
- Translation of “status code”: Changed from “状態コード” to “ステータスコード” This was done because it was determined that this would be understood as a general noun.
- Translation of “context”: Changed from ‘文脈’ to “Context”. While the word's meaning is “context,” here it refers to `gin.Context`, so it was just as `Context`.

---

日本語の翻訳のニュアンスについてなので日本語で記述します。

特に以下の単語を修正している。

- request の翻訳：要求→リクエストに修正。一般名詞としてこれで通じると判断したため。
- response の翻訳：応答→レスポンスに修正。一般名詞としてこれで通じると判断したため。
- status code の翻訳：状態コード→ステータスコードに修正。一般名詞としてこれで通じると判断したため。
- context の翻訳：文脈→Context に修正。単語の意味としては文脈だが、ここでは `gin.Context` を指しているので、そのまま `Context` と記載。
