### PR TITLE
fix(docs/testing): correct router usage in testing example

### DIFF
--- a/src/content/docs/en/docs/testing/index.md
+++ b/src/content/docs/en/docs/testing/index.md
@@ -37,7 +37,7 @@ func postUser(router *gin.Engine) *gin.Engine {
 
 func main() {
   router := setupRouter()
-  router = postUser(r)
+  router = postUser(router)
   router.Run(":8080")
 }
 ```

--- a/src/content/docs/id/docs/testing/index.md
+++ b/src/content/docs/id/docs/testing/index.md
@@ -37,7 +37,7 @@ func postUser(router *gin.Engine) *gin.Engine {
 
 func main() {
   router := setupRouter()
-  router = postUser(r)
+  router = postUser(router)
   router.Run(":8080")
 }
 ```

--- a/src/content/docs/ru/docs/testing/index.md
+++ b/src/content/docs/ru/docs/testing/index.md
@@ -37,7 +37,7 @@ func postUser(router *gin.Engine) *gin.Engine {
 
 func main() {
   router := setupRouter()
-  router = postUser(r)
+  router = postUser(router)
   router.Run(":8080")
 }
 ```


### PR DESCRIPTION
Changed `router = postUser(r)` to `router = postUser(router)` in the docs/testing example.