### PR TITLE
Bug fix: Arabic and Persian are unreadible due to writing direction

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -49,6 +49,10 @@ html[lang='ar'] * {
 		text-align: left;
 	}
 
+	kbd {
+		flex-direction: row-reverse;
+	}
+
 	a[rel="next"] svg {
 		rotate: 180deg;
 	}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -10,11 +10,11 @@ Add styles or override variables from the theme here.
 
 	--gin-blue: hsl(215, 69%, 52%);
 
-    --sl-hue-blue: 215;
+	--sl-hue-blue: 215;
 	--sl-color-blue-low: hsl(var(--sl-hue-blue), 54%, 20%);
 	--sl-color-blue: hsl(var(--sl-hue-blue), 100%, 60%);
 	--sl-color-blue-high: hsl(var(--sl-hue-blue), 100%, 87%);
-	
+
 	--sl-color-accent-low: hsl(204, 54%, 20%);
 	--sl-color-accent: hsl(204, 100%, 60%);
 	--sl-color-accent-high: hsl(204, 100%, 85%);
@@ -26,7 +26,7 @@ Add styles or override variables from the theme here.
 :root[data-theme='light'],
 [data-theme='light'] ::backdrop {
 	/* Colours (light mode) */
-	
+
 	--sl-color-blue-high: hsl(var(--sl-hue-blue), 80%, 30%);
 	--sl-color-blue: hsl(var(--sl-hue-blue), 90%, 60%);
 	--sl-color-blue-low: hsl(var(--sl-hue-blue), 88%, 90%);
@@ -34,4 +34,26 @@ Add styles or override variables from the theme here.
 	--sl-color-accent-high: hsl(215, 80%, 30%);
 	--sl-color-accent: hsl(215, 90%, 60%);
 	--sl-color-accent-low: hsl(215, 88%, 90%);
+}
+
+/* Fix writing direction when the language is set to arabic */
+html[lang='ar'] * {
+	direction: rtl;
+
+	pre,
+	.code,
+	.expressive-code,
+	.expressive-code *,
+	code span {
+		direction: ltr;
+		text-align: left;
+	}
+
+	a[rel="next"] svg {
+		rotate: 180deg;
+	}
+
+	a[rel="prev"] svg {
+		rotate: 180deg;
+	}
 }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -36,8 +36,10 @@ Add styles or override variables from the theme here.
 	--sl-color-accent-low: hsl(215, 88%, 90%);
 }
 
-/* Fix writing direction when the language is set to arabic */
-html[lang='ar'] * {
+/* Fix writing direction when the language is set to arabic and persian */
+/* The fix should be applied to all RTL languages, if more to be added in the future */
+html[lang='ar'] *,
+html[lang='fa'] * {
 	direction: rtl;
 
 	pre,


### PR DESCRIPTION
### Bug fix: Arabic language layout breaks readability in docs

**Description:**
When viewing the Gin framework documentation in Arabic (`lang="ar"`), mixed Arabic and English text is rendered incorrectly. English terms inside Arabic sentences are not properly isolated, causing the text flow to become confusing and hard to read.

**Expected:**
Proper RTL rendering with English segments kept readable and correctly ordered.

**Actual:**
Mixed Arabic/English text appears visually jumbled and reduces readability.

**Steps to reproduce:**

1. Open Gin docs website
2. Switch language to Arabic
3. View any page containing mixed Arabic + English text

---

**Before fix:**

<img width="1366" height="764" alt="image" src="https://github.com/user-attachments/assets/b8d263cb-15fb-4565-ae9a-a35217ad9b81" />

---

**After fix:**

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/6fd72e72-ab2d-4a86-8e16-d04b5f2ddc06" />

