### PR TITLE
ci(trivy): upgrade aquasecurity/trivy-action to v0.36.0

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Trivy vulnerability scanner (source code)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -44,7 +44,7 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
       - name: Run Trivy scanner (table output for logs)
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@v0.36.0
         if: always()
         with:
           scan-type: 'fs'


### PR DESCRIPTION
## Summary

- Upgrade `aquasecurity/trivy-action` from `0.35.0` to `v0.36.0` in the Trivy security scan workflow (both scan steps)

Note: switched to the `v`-prefixed tag, since the `0.36.0` release only publishes the `v0.36.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)